### PR TITLE
Implement MockInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const app = config(express(), {
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },
+  port: PORT,
   showLoginPage: process.env.SHOW_LOGIN_PAGE === 'true',
 })
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -8,6 +8,8 @@ const readFrom = p => fs.readFileSync(path.resolve(__dirname, p), 'utf8')
 const TEMPLATE = readFrom('../static/saml/unsigned-assertion.xml')
 const corpPassTemplate = readFrom('../static/saml/corppass.xml')
 
+const MYINFO = JSON.parse(readFrom('../static/myinfo.json'))
+
 const identities = {
   singPass: [
     'S8979373D',
@@ -45,6 +47,7 @@ const identities = {
     'F1612358R',
     'F1612354N',
     'F1612357U',
+    ...Object.keys(MYINFO),
   ],
   corpPass: [
     { NRIC: 'S8979373D', UEN: '123456789A' },
@@ -75,4 +78,5 @@ module.exports = {
     create: makeCorpPass,
   },
   identities,
+  MYINFO,
 }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -8,7 +8,7 @@ const readFrom = p => fs.readFileSync(path.resolve(__dirname, p), 'utf8')
 const TEMPLATE = readFrom('../static/saml/unsigned-assertion.xml')
 const corpPassTemplate = readFrom('../static/saml/corppass.xml')
 
-const MYINFO = JSON.parse(readFrom('../static/myinfo.json'))
+const myinfo = JSON.parse(readFrom('../static/myinfo.json'))
 
 const identities = {
   singPass: [
@@ -47,7 +47,7 @@ const identities = {
     'F1612358R',
     'F1612354N',
     'F1612357U',
-    ...Object.keys(MYINFO),
+    ...Object.keys(myinfo.personas),
   ],
   corpPass: [
     { NRIC: 'S8979373D', UEN: '123456789A' },
@@ -78,5 +78,5 @@ module.exports = {
     create: makeCorpPass,
   },
   identities,
-  MYINFO,
+  myinfo,
 }

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
 const { SignedXml } = require('xml-crypto')
@@ -11,6 +12,30 @@ module.exports = (serviceProvider) => {
     pem: serviceProvider.cert,
     encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
     keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5',
+  }
+
+  const baseString = function baseString ({
+    httpMethod,
+    url,
+    appId,
+    clientId,
+    singpassEserviceId,
+    nonce,
+    requestedAttributes,
+    timestamp,
+  }) {
+    return httpMethod.toUpperCase() +
+      // url string replacement was dictated by MyInfo docs - no explanation
+      // was provided for why this is necessary
+      '&' + url.replace('.api.gov.sg', '.e.api.gov.sg') +
+      '&apex_l2_eg_app_id=' + appId +
+      '&apex_l2_eg_nonce=' + nonce +
+      '&apex_l2_eg_signature_method=SHA256withRSA' +
+      '&apex_l2_eg_timestamp=' + timestamp +
+      '&apex_l2_eg_version=1.0' +
+      '&attributes=' + requestedAttributes +
+      '&client_id=' + clientId +
+      '&singpassEserviceId=' + singpassEserviceId
   }
 
   return {
@@ -53,5 +78,12 @@ module.exports = (serviceProvider) => {
           : resolve(`<saml:EncryptedAssertion>${data}</saml:EncryptedAssertion>`)
       )
     }),
+
+    verifyMyInfoSignature (signature, baseStringFields) {
+      const verifier = crypto.createVerify('RSA-SHA256')
+      verifier.update(baseString(baseStringFields))
+      verifier.end()
+      return verifier.verify(serviceProvider.pubKey, signature, 'base64')
+    },
   }
 }

--- a/lib/express.js
+++ b/lib/express.js
@@ -80,6 +80,11 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
       }
     )
   }
+
+  app.get('/myinfo/person-basic/:uinfin/', (req, res) => {
+    res.send(assertions.MYINFO[req.params.uinfin])
+  })
+
   return app
 }
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -129,7 +129,11 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, port }) {
 
       authHeaderFields.httpMethod = req.method
       // HACK: kludge the URL together
-      authHeaderFields.url = `http://${req.hostname}:${port}${req.baseUrl}${req.path}`
+      const hostPort = ['localhost', '127.0.0.1'].includes(req.hostname)
+        ? `${req.hostname}:${port}`
+        : req.hostname
+
+      authHeaderFields.url = `http://${hostPort}${req.baseUrl}${req.path}`
       authHeaderFields.requestedAttributes = req.query.attributes
 
       if (verifyMyInfoSignature(authHeaderFields.signature, authHeaderFields)) {

--- a/lib/express.js
+++ b/lib/express.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const bodyParser = require('body-parser')
 const fs = require('fs')
 const { pick, partition } = require('lodash')
@@ -17,8 +18,8 @@ const dom = xmlString => domParser.parseFromString(xmlString)
 const TEMPLATE = fs.readFileSync(path.resolve(__dirname, '../static/saml/unsigned-response.xml'), 'utf8')
 const LOGIN_TEMPLATE = fs.readFileSync(path.resolve(__dirname, '../static/html/login-page.html'), 'utf8')
 
-function config (app, { showLoginPage, serviceProvider, idpConfig }) {
-  const { verifySignature, sign, promiseToEncryptAssertion } = crypto(serviceProvider)
+function config (app, { showLoginPage, serviceProvider, idpConfig, port }) {
+  const { verifySignature, verifyMyInfoSignature, sign, promiseToEncryptAssertion } = crypto(serviceProvider)
   app.use(morgan('combined'))
 
   for (const idp of ['singPass', 'corpPass']) {
@@ -105,7 +106,37 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
 
   const allowedAttributes = assertions.myinfo.attributes
 
-  app.get('/myinfo/person-basic/:uinfin/', lookupPerson(allowedAttributes.basic))
+  app.get(
+    '/myinfo/person-basic/:uinfin/',
+    (req, res, next) => {
+      const [, authHeader] = req.get('Authorization').split(' ')
+      const authHeaderFieldPairs = _(authHeader)
+        .replace(/"/g, '')
+        .replace(/apex_l2_eg_/g, '')
+        .split(',')
+        .map(v => v.replace('=', '~').split('~'))
+
+      const authHeaderFields = _(authHeaderFieldPairs)
+        .fromPairs()
+        .mapKeys((v, k) => _.camelCase(k))
+        .value()
+
+      authHeaderFields.clientId = authHeaderFields.appId
+      authHeaderFields.singpassEserviceId = authHeaderFields.appId.replace(/^[^-]+-/, '')
+
+      authHeaderFields.httpMethod = req.method
+      // HACK: kludge the URL together
+      authHeaderFields.url = `http://${req.hostname}:${port}${req.baseUrl}${req.path}`
+      authHeaderFields.requestedAttributes = req.query.attributes
+
+      if (verifyMyInfoSignature(authHeaderFields.signature, authHeaderFields)) {
+        next()
+      } else {
+        res.status(403).send({ code: 403, message: 'Digital Service is invalid', fields: '' })
+      }
+    },
+    lookupPerson(allowedAttributes.basic)
+  )
   app.get('/myinfo/person/:uinfin/', lookupPerson([...allowedAttributes.basic, ...allowedAttributes.income]))
 
   return app

--- a/lib/express.js
+++ b/lib/express.js
@@ -1,5 +1,6 @@
 const bodyParser = require('body-parser')
 const fs = require('fs')
+const { pick, partition } = require('lodash')
 const morgan = require('morgan')
 const { render } = require('mustache')
 const path = require('path')
@@ -81,9 +82,31 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
     )
   }
 
-  app.get('/myinfo/person-basic/:uinfin/', (req, res) => {
-    res.send(assertions.MYINFO[req.params.uinfin])
-  })
+  const lookupPerson = allowedAttributes => (req, res) => {
+    const requestedAttributes = (req.query.attributes || '').split(',')
+
+    const [attributes, disallowedAttributes] = partition(
+      requestedAttributes,
+      v => allowedAttributes.includes(v)
+    )
+
+    if (disallowedAttributes.length > 0) {
+      res.status(401).send({ code: 401, message: 'Disallowed', fields: disallowedAttributes.join(',') })
+    } else {
+      const persona = assertions.myinfo.personas[req.params.uinfin]
+      res.status(persona ? 200 : 404)
+        .send(
+          persona
+            ? pick(persona, attributes)
+            : { code: 404, message: 'Not Found', fields: req.params.uinfin }
+        )
+    }
+  }
+
+  const allowedAttributes = assertions.myinfo.attributes
+
+  app.get('/myinfo/person-basic/:uinfin/', lookupPerson(allowedAttributes.basic))
+  app.get('/myinfo/person/:uinfin/', lookupPerson([...allowedAttributes.basic, ...allowedAttributes.income]))
 
   return app
 }

--- a/lib/express.js
+++ b/lib/express.js
@@ -98,7 +98,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
         .send(
           persona
             ? pick(persona, attributes)
-            : { code: 404, message: 'Not Found', fields: req.params.uinfin }
+            : { code: 404, message: 'UIN/FIN does not exist in MyInfo.', fields: '' }
         )
     }
   }

--- a/lib/express.js
+++ b/lib/express.js
@@ -27,14 +27,17 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, port }) {
       const relayState = encodeURIComponent(req.query.Target)
       if (showLoginPage) {
         const identities = assertions.identities[idp]
-        const someValues = identities
+        const values = identities
           .map((id, index) => {
             const samlArt = samlArtifact(idpConfig[idp].id, index)
             const assertURL =
               `${idpConfig[idp].assertEndpoint}?SAMLart=${samlArt}&RelayState=${relayState}`
+            if (assertions.myinfo.personas[id]) {
+              id += ' [MyInfo]'
+            }
             return { id, assertURL }
           })
-        const response = render(LOGIN_TEMPLATE, someValues)
+        const response = render(LOGIN_TEMPLATE, values)
         res.send(response)
       } else {
         const samlArt = samlArtifact(idpConfig[idp].id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1076,9 +1076,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "express": "^4.16.3",
+    "lodash": "^4.17.11",
     "morgan": "^1.9.1",
     "mustache": "^2.3.2",
     "xml-crypto": "^1.1.1",

--- a/static/myinfo.json
+++ b/static/myinfo.json
@@ -1,6103 +1,6155 @@
+
 {
-  "S9912369I": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "PATRICIA KIM WAI MUN"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MRS PATRICIA KIM WAI MUN"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MX"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1999-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E1234577F"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2020-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "11",
-      "street": "BEDOK RESERVOIR ROAD",
-      "lastupdated": "2018-03-20",
-      "block": "113",
-      "source": "1",
-      "postal": "470113",
-      "classification": "C",
-      "floor": "03",
-      "building": "EUNOS VISTA"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "114"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "2"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "901889"
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2012-02-15"
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "HK",
-        "race": "CN",
-        "tob": "0901",
-        "sex": "F",
-        "source": "1",
-        "classification": "C",
-        "birthcertno": "S5562882C",
-        "hanyupinyinname": "Cheng Pei Ni",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2011-09-10",
-        "name": "Jo Tan Pei Ni",
-        "lastupdated": "2018-05-16",
-        "secondaryrace": ""
-      },
-      {
-        "dialect": "HK",
-        "race": "CN",
-        "tob": "2021",
-        "sex": "F",
-        "source": "1",
-        "classification": "C",
-        "birthcertno": "S8816582I",
-        "hanyupinyinname": "Cheng Wei Ling",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2015-07-18",
-        "name": "Joyce Tan Wei Ling",
-        "lastupdated": "2018-05-16",
-        "secondaryrace": ""
-      },
-      {
-        "dialect": "HK",
-        "race": "CN",
-        "tob": "0901",
-        "sex": "F",
-        "source": "1",
-        "classification": "C",
-        "birthcertno": "T0202564C",
-        "hanyupinyinname": "Cheng Shu Hui",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2012-09-10",
-        "name": "Joycelyn Tan Shu Hui",
-        "lastupdated": "2018-05-16",
-        "secondaryrace": ""
-      }
+  "attributes": {
+    "basic": [
+      "name",
+      "hanyupinyinname",
+      "aliasname",
+      "hanyupinyinaliasname",
+      "marriedname",
+      "sex",
+      "race",
+      "secondaryrace",
+      "dialect",
+      "nationality",
+      "dob",
+      "birthcountry",
+      "residentialstatus",
+      "passportnumber",
+      "passportexpirydate",
+      "regadd",
+      "mailadd",
+      "billadd",
+      "housingtype",
+      "hdbtype",
+      "email",
+      "homeno",
+      "mobileno",
+      "marital",
+      "marriagecertno",
+      "countryofmarriage",
+      "marriagedate",
+      "divorcedate",
+      "childrenbirthrecords",
+      "edulevel",
+      "gradyear",
+      "schoolname",
+      "occupation",
+      "employment",
+      "householdincome",
+      "workpassstatus",
+      "workpassexpirydate",
+      "vehno"
     ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "9"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "2001"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "NTU",
-      "desc": "NANYANG TECHNOLOGICAL UNIVERSITY"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "13304",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "AAS Sistemas Pte Ltd"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "above",
-      "source": "2",
-      "classification": "C",
-      "low": "2000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "923456789.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    "income": [
+      "ownerprivate",
+      "assessableincome",
+      "assessyear",
+      "cpfcontributions",
+      "cpfbalances"
+    ]
+  },
+  "personas": {
+    "S9912369I": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "PATRICIA KIM WAI MUN"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MRS PATRICIA KIM WAI MUN"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MX"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1999-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E1234577F"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2020-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "11",
+        "street": "BEDOK RESERVOIR ROAD",
+        "lastupdated": "2018-03-20",
+        "block": "113",
+        "source": "1",
+        "postal": "470113",
+        "classification": "C",
+        "floor": "03",
+        "building": "EUNOS VISTA"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "114"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "2"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "901889"
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2012-02-15"
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2614-12-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2014-12"
+          "dialect": "HK",
+          "race": "CN",
+          "tob": "0901",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S5562882C",
+          "hanyupinyinname": "Cheng Pei Ni",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2011-09-10",
+          "name": "Jo Tan Pei Ni",
+          "lastupdated": "2018-05-16",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-01-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-01"
+          "dialect": "HK",
+          "race": "CN",
+          "tob": "2021",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8816582I",
+          "hanyupinyinname": "Cheng Wei Ling",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2015-07-18",
+          "name": "Joyce Tan Wei Ling",
+          "lastupdated": "2018-05-16",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-02-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-02"
-        },
-        {
-          "date": "2615-03-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-03"
-        },
-        {
-          "date": "2615-04-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-04"
-        },
-        {
-          "date": "2615-05-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-05"
-        },
-        {
-          "date": "2615-06-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-06"
-        },
-        {
-          "date": "2615-07-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-07"
-        },
-        {
-          "date": "2615-08-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-08"
-        },
-        {
-          "date": "2615-09-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-09"
-        },
-        {
-          "date": "2615-10-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-10"
-        },
-        {
-          "date": "2615-11-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-11"
-        },
-        {
-          "date": "2615-12-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2015-12"
-        },
-        {
-          "date": "2616-01-28",
-          "employer": "AAS SISTEMAS PTE LTD",
-          "amount": "5626.67",
-          "month": "2016-01"
+          "dialect": "HK",
+          "race": "CN",
+          "tob": "0901",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T0202564C",
+          "hanyupinyinname": "Cheng Shu Hui",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2012-09-10",
+          "name": "Joycelyn Tan Shu Hui",
+          "lastupdated": "2018-05-16",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "9"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "2001"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "NTU",
+        "desc": "NANYANG TECHNOLOGICAL UNIVERSITY"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "13304",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "AAS Sistemas Pte Ltd"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "above",
+        "source": "2",
+        "classification": "C",
+        "low": "2000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "923456789.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2614-12-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2014-12"
+          },
+          {
+            "date": "2615-01-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-01"
+          },
+          {
+            "date": "2615-02-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-02"
+          },
+          {
+            "date": "2615-03-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-03"
+          },
+          {
+            "date": "2615-04-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-04"
+          },
+          {
+            "date": "2615-05-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-05"
+          },
+          {
+            "date": "2615-06-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-06"
+          },
+          {
+            "date": "2615-07-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-07"
+          },
+          {
+            "date": "2615-08-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-08"
+          },
+          {
+            "date": "2615-09-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-09"
+          },
+          {
+            "date": "2615-10-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-10"
+          },
+          {
+            "date": "2615-11-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-11"
+          },
+          {
+            "date": "2615-12-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2015-12"
+          },
+          {
+            "date": "2616-01-28",
+            "employer": "AAS SISTEMAS PTE LTD",
+            "amount": "5626.67",
+            "month": "2016-01"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2017-03-16",
+        "oa": "1581.48",
+        "source": "1",
+        "ma": "21967.09",
+        "classification": "C",
+        "sa": "11470.70"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "SKK789T"
+      }
     },
-    "cpfbalances": {
-      "lastupdated": "2017-03-16",
-      "oa": "1581.48",
-      "source": "1",
-      "ma": "21967.09",
-      "classification": "C",
-      "sa": "11470.70"
+    "S9912370B": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "ELIZABERTH PIERCE JOHNSON"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MRS ELIZABERTH PIERCE JOHNSON"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1999-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E3546374W"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2023-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "",
+        "street": "ROCHDALE ROAD",
+        "lastupdated": "2018-03-20",
+        "block": "29",
+        "source": "1",
+        "postal": "535842",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "SG",
+        "unit": "1234",
+        "street": "ANG MO KIO AVENUE 5",
+        "lastupdated": "2018-03-20",
+        "block": "154",
+        "source": "2",
+        "postal": "560154",
+        "classification": "C",
+        "floor": "12",
+        "building": "YIO CHU KANG GROVE"
+      },
+      "billadd": {
+        "country": "",
+        "unit": "11",
+        "street": "ANG MO KIO AVENUE 5",
+        "lastupdated": "2018-03-20",
+        "block": "153",
+        "source": "2",
+        "postal": "560153",
+        "classification": "",
+        "floor": "10",
+        "building": "YIO CHU KANG GROVE"
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "122"
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "Y"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "3"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
+        {}
+      ],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "2001"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS0701A",
+        "desc": "NATIONAL JUNIOR COLLEGE"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "12123",
+        "desc": "TRAINING MANAGER"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "balik kampung pte ltd"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "1999",
+        "source": "2",
+        "classification": "C",
+        "low": "1000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2614-12-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2014-12"
+          },
+          {
+            "date": "2615-01-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-01"
+          },
+          {
+            "date": "2615-02-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-02"
+          },
+          {
+            "date": "2615-03-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-03"
+          },
+          {
+            "date": "2615-04-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-04"
+          },
+          {
+            "date": "2615-05-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-05"
+          },
+          {
+            "date": "2615-06-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-06"
+          },
+          {
+            "date": "2615-07-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-07"
+          },
+          {
+            "date": "2615-08-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-08"
+          },
+          {
+            "date": "2615-09-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-09"
+          },
+          {
+            "date": "2615-10-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-10"
+          },
+          {
+            "date": "2615-11-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-11"
+          },
+          {
+            "date": "2615-12-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2015-12"
+          },
+          {
+            "date": "2616-01-28",
+            "employer": "BALIK KAMPUNG PTE LTD",
+            "amount": "1865.21",
+            "month": "2016-01"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "0.00",
+        "source": "1",
+        "ma": "0.00",
+        "classification": "C",
+        "sa": "0.00"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "SJY1234R"
+      }
     },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "SKK789T"
-    }
-  },
-  "S9912370B": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "ELIZABERTH PIERCE JOHNSON"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MRS ELIZABERTH PIERCE JOHNSON"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1999-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E3546374W"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2023-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "",
-      "street": "ROCHDALE ROAD",
-      "lastupdated": "2018-03-20",
-      "block": "29",
-      "source": "1",
-      "postal": "535842",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "SG",
-      "unit": "1234",
-      "street": "ANG MO KIO AVENUE 5",
-      "lastupdated": "2018-03-20",
-      "block": "154",
-      "source": "2",
-      "postal": "560154",
-      "classification": "C",
-      "floor": "12",
-      "building": "YIO CHU KANG GROVE"
-    },
-    "billadd": {
-      "country": "",
-      "unit": "11",
-      "street": "ANG MO KIO AVENUE 5",
-      "lastupdated": "2018-03-20",
-      "block": "153",
-      "source": "2",
-      "postal": "560153",
-      "classification": "",
-      "floor": "10",
-      "building": "YIO CHU KANG GROVE"
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "122"
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "Y"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "3"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {}
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "2001"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS0701A",
-      "desc": "NATIONAL JUNIOR COLLEGE"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "12123",
-      "desc": "TRAINING MANAGER"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "balik kampung pte ltd"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "1999",
-      "source": "2",
-      "classification": "C",
-      "low": "1000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    "S9912374E": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "TIMOTHY TAN CHENG GUAN"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CHEN CHENG GUAN, TIMOTHY"
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "US"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "GN"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1990-04-19"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "US"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "P"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E1234567F"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2024-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "367",
+        "street": "JURONG EAST AVENUE 1",
+        "lastupdated": "2018-03-20",
+        "block": "35",
+        "postal": "609774",
+        "source": "1",
+        "classification": "C",
+        "floor": "08",
+        "building": "PARC OASIS"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "postal": "",
+        "source": "",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "postal": "",
+        "source": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "131"
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "2"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "810203"
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "1990-02-15"
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2614-12-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2014-12"
+          "dialect": "",
+          "race": "CN",
+          "tob": "0901",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1401234A",
+          "hanyupinyinname": "Cheng Yi Sheng",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2014-03-10",
+          "name": "Anthony Tan Yi Sheng",
+          "lastupdated": "2014-03-10",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-01-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-01"
-        },
-        {
-          "date": "2615-02-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-02"
-        },
-        {
-          "date": "2615-03-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-03"
-        },
-        {
-          "date": "2615-04-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-04"
-        },
-        {
-          "date": "2615-05-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-05"
-        },
-        {
-          "date": "2615-06-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-06"
-        },
-        {
-          "date": "2615-07-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-07"
-        },
-        {
-          "date": "2615-08-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-08"
-        },
-        {
-          "date": "2615-09-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-09"
-        },
-        {
-          "date": "2615-10-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-10"
-        },
-        {
-          "date": "2615-11-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-11"
-        },
-        {
-          "date": "2615-12-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2015-12"
-        },
-        {
-          "date": "2616-01-28",
-          "employer": "BALIK KAMPUNG PTE LTD",
-          "amount": "1865.21",
-          "month": "2016-01"
+          "dialect": "",
+          "race": "CN",
+          "tob": "1828",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1519876K",
+          "hanyupinyinname": "Cheng Li Yin",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2015-05-12",
+          "name": "Melody Tan Li Yin",
+          "lastupdated": "2015-05-12",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "0.00",
-      "source": "1",
-      "ma": "0.00",
-      "classification": "C",
-      "sa": "0.00"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "SJY1234R"
-    }
-  },
-  "S9912374E": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "TIMOTHY TAN CHENG GUAN"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CHEN CHENG GUAN, TIMOTHY"
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "US"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "GN"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1990-04-19"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "US"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "P"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E1234567F"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2024-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "367",
-      "street": "JURONG EAST AVENUE 1",
-      "lastupdated": "2018-03-20",
-      "block": "35",
-      "postal": "609774",
-      "source": "1",
-      "classification": "C",
-      "floor": "08",
-      "building": "PARC OASIS"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "postal": "",
-      "source": "",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "postal": "",
-      "source": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "131"
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "2"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "810203"
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "1990-02-15"
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "",
-        "race": "CN",
-        "tob": "0901",
-        "sex": "F",
-        "source": "1",
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
         "classification": "C",
-        "birthcertno": "T1401234A",
-        "hanyupinyinname": "Cheng Yi Sheng",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2014-03-10",
-        "name": "Anthony Tan Yi Sheng",
-        "lastupdated": "2014-03-10",
-        "secondaryrace": ""
+        "value": "7"
       },
-      {
-        "dialect": "",
-        "race": "CN",
-        "tob": "1828",
-        "sex": "F",
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "2001"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS0805J",
+        "desc": "NANYANG JUNIOR COLLEGE"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "21453",
+        "desc": "CHEMICAL ENGINEER (PETROCHEMICALS)"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "front pal chemicals pte ltd"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "3999",
+        "source": "2",
+        "classification": "C",
+        "low": "3000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
         "source": "1",
         "classification": "C",
-        "birthcertno": "T1519876K",
-        "hanyupinyinname": "Cheng Li Yin",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2015-05-12",
-        "name": "Melody Tan Li Yin",
-        "lastupdated": "2015-05-12",
-        "secondaryrace": ""
+        "value": "2456789"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2614-12-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2014-12"
+          },
+          {
+            "date": "2615-01-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-01"
+          },
+          {
+            "date": "2615-02-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-02"
+          },
+          {
+            "date": "2615-03-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-03"
+          },
+          {
+            "date": "2615-04-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-04"
+          },
+          {
+            "date": "2615-05-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-05"
+          },
+          {
+            "date": "2615-06-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-06"
+          },
+          {
+            "date": "2615-07-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-07"
+          },
+          {
+            "date": "2615-08-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-08"
+          },
+          {
+            "date": "2615-09-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-09"
+          },
+          {
+            "date": "2615-10-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-10"
+          },
+          {
+            "date": "2615-11-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-11"
+          },
+          {
+            "date": "2615-12-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2015-12"
+          },
+          {
+            "date": "2616-01-28",
+            "employer": "EYEWEAR OPTICS PTE LTD",
+            "amount": "4965.92",
+            "month": "2016-01"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "27857.35",
+        "source": "1",
+        "ma": "90253.27",
+        "classification": "C",
+        "sa": "30635.84"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
       }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "7"
     },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "2001"
+    "S9912366D":{
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "FATIMAH"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1980-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E4645364P"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "12",
+        "street": "BRADDELL HILL",
+        "lastupdated": "2018-03-20",
+        "block": "10",
+        "source": "1",
+        "postal": "579719",
+        "classification": "C",
+        "floor": "23",
+        "building": "BRADDELL VIEW"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "139"
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "5"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2011-02-28"
+      },
+      "childrenbirthrecords": [
+        {}
+      ],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "0.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "0.00",
+        "source": "1",
+        "ma": "0.00",
+        "classification": "C",
+        "sa": "0.00"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "SBA9988K"
+      }
     },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS0805J",
-      "desc": "NANYANG JUNIOR COLLEGE"
+    "F1612347K": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "TAN AH HONG"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1960-05-17"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "2018-03-20",
+        "block": "",
+        "source": "1",
+        "postal": "",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "SG",
+        "unit": "12413",
+        "street": "BEDOK NORTH ROAD",
+        "lastupdated": "2018-08-23",
+        "block": "180",
+        "source": "2",
+        "postal": "460180",
+        "classification": "",
+        "floor": "12",
+        "building": "VISTA 8"
+      },
+      "billadd": {
+        "country": "SG",
+        "unit": "12413",
+        "street": "BEDOK NORTH ROAD",
+        "lastupdated": "2018-08-23",
+        "block": "180",
+        "source": "2",
+        "postal": "460180",
+        "classification": "",
+        "floor": "12",
+        "building": "VISTA 8"
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "Y"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "",
+        "desc": "OPERATION MANAGER"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "MULTI GRIP MARINE ENGRG"
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "Live"
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "2019-12-31"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "7999",
+        "source": "2",
+        "classification": "C",
+        "low": "7000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "323456789"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "",
+        "source": "1",
+        "ma": "",
+        "classification": "C",
+        "sa": ""
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      }
     },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "21453",
-      "desc": "CHEMICAL ENGINEER (PETROCHEMICALS)"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "front pal chemicals pte ltd"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "3999",
-      "source": "2",
-      "classification": "C",
-      "low": "3000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2456789"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    "G1612352N": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "AMY CHONG GAN CHENG"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "AR"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "TH"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1961-06-17"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "US"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E3546387W"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "2018-03-20",
+        "block": "",
+        "source": "1",
+        "postal": "",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "SG",
+        "unit": "123",
+        "street": "BEDOK RESERVOIR ROAD",
+        "lastupdated": "2018-08-23",
+        "block": "613B",
+        "source": "2",
+        "postal": "472613",
+        "classification": "",
+        "floor": "05",
+        "building": "HDB-BEDOK"
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "2"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "290229"
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2017-01-03"
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2614-12-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2014-12"
+          "dialect": "CT",
+          "race": "CN",
+          "tob": "1419",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1203367F",
+          "hanyupinyinname": "Zheng Xue Ling",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2012-01-12",
+          "name": "Tay Xue Ling, Christina",
+          "lastupdated": "2012-01-12",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-01-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-01"
+          "dialect": "CT",
+          "race": "CN",
+          "tob": "1956",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1316755J",
+          "hanyupinyinname": "Zheng Xue Wei",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2013-07-18",
+          "name": "Tay Xue Wei, Michelle",
+          "lastupdated": "2013-07-19",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-02-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-02"
+          "dialect": "CT",
+          "race": "CN",
+          "tob": "1601",
+          "sex": "M",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1502351D",
+          "hanyupinyinname": "Zheng Wei Ming",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2015-11-20",
+          "name": "Tay Wei Ming, Ronaldo",
+          "lastupdated": "2015-11-20",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-03-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-03"
-        },
-        {
-          "date": "2615-04-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-04"
-        },
-        {
-          "date": "2615-05-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-05"
-        },
-        {
-          "date": "2615-06-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-06"
-        },
-        {
-          "date": "2615-07-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-07"
-        },
-        {
-          "date": "2615-08-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-08"
-        },
-        {
-          "date": "2615-09-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-09"
-        },
-        {
-          "date": "2615-10-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-10"
-        },
-        {
-          "date": "2615-11-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-11"
-        },
-        {
-          "date": "2615-12-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2015-12"
-        },
-        {
-          "date": "2616-01-28",
-          "employer": "EYEWEAR OPTICS PTE LTD",
-          "amount": "4965.92",
-          "month": "2016-01"
+          "dialect": "CT",
+          "race": "CN",
+          "tob": "2200",
+          "sex": "M",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1710092H",
+          "hanyupinyinname": "Zheng Wei Qiang",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2017-07-18",
+          "name": "Tay Wei Qiang, Messi",
+          "lastupdated": "2017-07-19",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "27857.35",
-      "source": "1",
-      "ma": "90253.27",
-      "classification": "C",
-      "sa": "30635.84"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "S9912366D":{
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "FATIMAH"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1980-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E4645364P"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "12",
-      "street": "BRADDELL HILL",
-      "lastupdated": "2018-03-20",
-      "block": "10",
-      "source": "1",
-      "postal": "579719",
-      "classification": "C",
-      "floor": "23",
-      "building": "BRADDELL VIEW"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "139"
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "5"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2011-02-28"
-    },
-    "childrenbirthrecords": [
-      {}
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "0.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "0.00",
-      "source": "1",
-      "ma": "0.00",
-      "classification": "C",
-      "sa": "0.00"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "SBA9988K"
-    }
-  },
-  "F1612347K": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "TAN AH HONG"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1960-05-17"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "2018-03-20",
-      "block": "",
-      "source": "1",
-      "postal": "",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "SG",
-      "unit": "12413",
-      "street": "BEDOK NORTH ROAD",
-      "lastupdated": "2018-08-23",
-      "block": "180",
-      "source": "2",
-      "postal": "460180",
-      "classification": "",
-      "floor": "12",
-      "building": "VISTA 8"
-    },
-    "billadd": {
-      "country": "SG",
-      "unit": "12413",
-      "street": "BEDOK NORTH ROAD",
-      "lastupdated": "2018-08-23",
-      "block": "180",
-      "source": "2",
-      "postal": "460180",
-      "classification": "",
-      "floor": "12",
-      "building": "VISTA 8"
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "Y"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "",
-      "desc": "OPERATION MANAGER"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "MULTI GRIP MARINE ENGRG"
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "Live"
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "2019-12-31"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "7999",
-      "source": "2",
-      "classification": "C",
-      "low": "7000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "323456789"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "",
-      "source": "1",
-      "ma": "",
-      "classification": "C",
-      "sa": ""
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "G1612352N": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "AMY CHONG GAN CHENG"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "AR"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "TH"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1961-06-17"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "US"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E3546387W"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "2018-03-20",
-      "block": "",
-      "source": "1",
-      "postal": "",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "SG",
-      "unit": "123",
-      "street": "BEDOK RESERVOIR ROAD",
-      "lastupdated": "2018-08-23",
-      "block": "613B",
-      "source": "2",
-      "postal": "472613",
-      "classification": "",
-      "floor": "05",
-      "building": "HDB-BEDOK"
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "2"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "290229"
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2017-01-03"
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "CT",
-        "race": "CN",
-        "tob": "1419",
-        "sex": "F",
-        "source": "1",
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
         "classification": "C",
-        "birthcertno": "T1203367F",
-        "hanyupinyinname": "Zheng Xue Ling",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2012-01-12",
-        "name": "Tay Xue Ling, Christina",
-        "lastupdated": "2012-01-12",
-        "secondaryrace": ""
+        "value": "7"
       },
-      {
-        "dialect": "CT",
-        "race": "CN",
-        "tob": "1956",
-        "sex": "F",
-        "source": "1",
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
         "classification": "C",
-        "birthcertno": "T1316755J",
-        "hanyupinyinname": "Zheng Xue Wei",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2013-07-18",
-        "name": "Tay Xue Wei, Michelle",
-        "lastupdated": "2013-07-19",
-        "secondaryrace": ""
+        "value": "2011"
       },
-      {
-        "dialect": "CT",
-        "race": "CN",
-        "tob": "1601",
-        "sex": "M",
-        "source": "1",
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
         "classification": "C",
-        "birthcertno": "T1502351D",
-        "hanyupinyinname": "Zheng Wei Ming",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2015-11-20",
-        "name": "Tay Wei Ming, Ronaldo",
-        "lastupdated": "2015-11-20",
-        "secondaryrace": ""
+        "value": "T07GS0705G",
+        "desc": "ANDERSON JUNIOR COLLEGE"
       },
-      {
-        "dialect": "CT",
-        "race": "CN",
-        "tob": "2200",
-        "sex": "M",
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "13304",
+        "desc": "IT SERVICE MANAGER"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "AH HUAT PTE LTD"
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
         "source": "1",
         "classification": "C",
-        "birthcertno": "T1710092H",
-        "hanyupinyinname": "Zheng Wei Qiang",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2017-07-18",
-        "name": "Tay Wei Qiang, Messi",
-        "lastupdated": "2017-07-19",
-        "secondaryrace": ""
+        "value": "Live"
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "2019-12-31"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "0.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "",
+        "source": "1",
+        "ma": "",
+        "classification": "C",
+        "sa": ""
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
       }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "7"
     },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "2011"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS0705G",
-      "desc": "ANDERSON JUNIOR COLLEGE"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "13304",
-      "desc": "IT SERVICE MANAGER"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "AH HUAT PTE LTD"
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "Live"
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "2019-12-31"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "0.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "",
-      "source": "1",
-      "ma": "",
-      "classification": "C",
-      "sa": ""
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "S9812379B": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "LIM YONG XIANG"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "LIN YONG XIANG"
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "JASCKSON LIM YONG XIANG"
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "JASCKSON LIN YONG XIANG"
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MR LIM YONG XIANG"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "GC"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1980-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "P"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "22",
-      "street": "LORONG 1 TOA PAYOH",
-      "lastupdated": "2018-03-20",
-      "block": "123",
-      "source": "1",
-      "postal": "310123",
-      "classification": "C",
-      "floor": "12",
-      "building": "TOA PAYOH VIEW"
-    },
-    "mailadd": {
-      "country": "SG",
-      "unit": "1234",
-      "street": "ANG MO KIO AVENUE 5",
-      "lastupdated": "2018-08-23",
-      "block": "154",
-      "source": "2",
-      "postal": "560154",
-      "classification": "",
-      "floor": "12",
-      "building": "YIO CHU KANG GROVE"
-    },
-    "billadd": {
-      "country": "",
-      "unit": "11",
-      "street": "ANG MO KIO AVENUE 5",
-      "lastupdated": "2018-08-23",
-      "block": "153",
-      "source": "2",
-      "postal": "560153",
-      "classification": "",
-      "floor": "10",
-      "building": "YIO CHU KANG GROVE"
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "113"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "5"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2015-01-01"
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "8"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1952"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T12GS0005D",
-      "desc": "SPRINGDALE PRIMARY SCHOOL"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "11110",
-      "desc": "LEGISLATOR"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "EXECUTIVE"
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "1999",
-      "source": "2",
-      "classification": "C",
-      "low": "1000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "oa": "141234.00",
-      "ma": "30245.00",
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "sa": "45123.00",
-      "ra": "30245.00"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "S9812381D": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "TAN XIAO HUI"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "TRICIA TAN XIAO HUI"
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1970-05-17"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "regadd": {
-      "country": "",
-      "unit": "128",
-      "street": "BEDOK NORTH AVENUE 4",
-      "lastupdated": "2018-03-20",
-      "block": "102",
-      "source": "1",
-      "postal": "460102",
-      "classification": "C",
-      "floor": "09",
-      "building": "PEARL GARDEN"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "113"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "TC",
-        "race": "CN",
-        "tob": "0933",
-        "sex": "F",
+    "S9812379B": {
+      "name": {
+        "lastupdated": "2018-03-20",
         "source": "1",
         "classification": "C",
-        "birthcertno": "T1108765Z",
-        "hanyupinyinname": "Cheng Yi Ting",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2011-04-13",
-        "name": "Tan Yee Teng",
-        "lastupdated": "2011-04-13",
-        "secondaryrace": ""
+        "value": "LIM YONG XIANG"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "LIN YONG XIANG"
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "JASCKSON LIM YONG XIANG"
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "JASCKSON LIN YONG XIANG"
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MR LIM YONG XIANG"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "GC"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1980-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "P"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "22",
+        "street": "LORONG 1 TOA PAYOH",
+        "lastupdated": "2018-03-20",
+        "block": "123",
+        "source": "1",
+        "postal": "310123",
+        "classification": "C",
+        "floor": "12",
+        "building": "TOA PAYOH VIEW"
+      },
+      "mailadd": {
+        "country": "SG",
+        "unit": "1234",
+        "street": "ANG MO KIO AVENUE 5",
+        "lastupdated": "2018-08-23",
+        "block": "154",
+        "source": "2",
+        "postal": "560154",
+        "classification": "",
+        "floor": "12",
+        "building": "YIO CHU KANG GROVE"
+      },
+      "billadd": {
+        "country": "",
+        "unit": "11",
+        "street": "ANG MO KIO AVENUE 5",
+        "lastupdated": "2018-08-23",
+        "block": "153",
+        "source": "2",
+        "postal": "560153",
+        "classification": "",
+        "floor": "10",
+        "building": "YIO CHU KANG GROVE"
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "113"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "5"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2015-01-01"
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "8"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1952"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T12GS0005D",
+        "desc": "SPRINGDALE PRIMARY SCHOOL"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "11110",
+        "desc": "LEGISLATOR"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "EXECUTIVE"
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "1999",
+        "source": "2",
+        "classification": "C",
+        "low": "1000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "oa": "141234.00",
+        "ma": "30245.00",
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "sa": "45123.00",
+        "ra": "30245.00"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
       }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "3"
     },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1978"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": "SIGLAP SECONDARY SCHOOL"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": "HEALTHCARE ASSISTANT"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "ALPHA"
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "4999",
-      "source": "2",
-      "classification": "C",
-      "low": "4000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "1456789.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    "S9812381D": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "TAN XIAO HUI"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "TRICIA TAN XIAO HUI"
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1970-05-17"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "regadd": {
+        "country": "",
+        "unit": "128",
+        "street": "BEDOK NORTH AVENUE 4",
+        "lastupdated": "2018-03-20",
+        "block": "102",
+        "source": "1",
+        "postal": "460102",
+        "classification": "C",
+        "floor": "09",
+        "building": "PEARL GARDEN"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "113"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2016-12-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2016-11"
-        },
-        {
-          "date": "2016-12-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2016-12"
-        },
-        {
-          "date": "2016-12-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2016-12"
-        },
-        {
-          "date": "2017-01-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2016-12"
-        },
-        {
-          "date": "2017-01-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-01"
-        },
-        {
-          "date": "2017-01-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-01"
-        },
-        {
-          "date": "2017-02-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-01"
-        },
-        {
-          "date": "2017-02-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-02"
-        },
-        {
-          "date": "2017-02-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-02"
-        },
-        {
-          "date": "2017-03-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-02"
-        },
-        {
-          "date": "2017-03-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-03"
-        },
-        {
-          "date": "2017-03-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-03"
-        },
-        {
-          "date": "2017-04-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-03"
-        },
-        {
-          "date": "2017-04-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-04"
-        },
-        {
-          "date": "2017-04-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-04"
-        },
-        {
-          "date": "2017-05-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-04"
-        },
-        {
-          "date": "2017-05-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-05"
-        },
-        {
-          "date": "2017-05-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-05"
-        },
-        {
-          "date": "2017-06-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-05"
-        },
-        {
-          "date": "2017-06-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-06"
-        },
-        {
-          "date": "2017-06-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-06"
-        },
-        {
-          "date": "2017-07-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-06"
-        },
-        {
-          "date": "2017-07-12",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-07"
-        },
-        {
-          "date": "2017-07-21",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-07"
-        },
-        {
-          "date": "2017-08-01",
-          "employer": "Crystal Horse Invest Pte Ltd",
-          "amount": "500.00",
-          "month": "2017-07"
-        },
-        {
-          "date": "2017-08-12",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-08"
-        },
-        {
-          "date": "2017-08-21",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-08"
-        },
-        {
-          "date": "2017-09-01",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-08"
-        },
-        {
-          "date": "2017-09-12",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-09"
-        },
-        {
-          "date": "2017-09-21",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-09"
-        },
-        {
-          "date": "2017-10-01",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-09"
-        },
-        {
-          "date": "2017-10-12",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-10"
-        },
-        {
-          "date": "2017-10-21",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-10"
-        },
-        {
-          "date": "2017-11-01",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-10"
-        },
-        {
-          "date": "2017-11-12",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-11"
-        },
-        {
-          "date": "2017-11-21",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-11"
-        },
-        {
-          "date": "2017-12-01",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-11"
-        },
-        {
-          "date": "2017-12-12",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-12"
-        },
-        {
-          "date": "2017-12-21",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-12"
-        },
-        {
-          "date": "2018-01-01",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2017-12"
-        },
-        {
-          "date": "2018-01-12",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2018-01"
-        },
-        {
-          "date": "2018-01-21",
-          "employer": "Delta Marine Consultants PL",
-          "amount": "750.00",
-          "month": "2018-01"
+          "dialect": "TC",
+          "race": "CN",
+          "tob": "0933",
+          "sex": "F",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1108765Z",
+          "hanyupinyinname": "Cheng Yi Ting",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2011-04-13",
+          "name": "Tan Yee Teng",
+          "lastupdated": "2011-04-13",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "1581.48",
-      "source": "1",
-      "ma": "11470.70",
-      "classification": "C",
-      "sa": "21967.09"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },  
-  "S9812382B": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "FREYA LIM GUO EN"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MRS FREYA LIM GUO EN"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "US"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1960-04-19"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "US"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "P"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E12345677F"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "367",
-      "street": "JURONG EAST STREET 21",
-      "lastupdated": "2018-03-20",
-      "block": "288A",
-      "source": "1",
-      "postal": "601288",
-      "classification": "C",
-      "floor": "08",
-      "building": "HDB-JURONG EAST"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "115"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "2"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "443172"
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2017-01-03"
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "TC",
-        "race": "CN",
-        "tob": "1045",
-        "sex": "M",
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "3"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1978"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": "SIGLAP SECONDARY SCHOOL"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": "HEALTHCARE ASSISTANT"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "ALPHA"
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
         "source": "1",
         "classification": "C",
-        "birthcertno": "T1512909G",
-        "hanyupinyinname": "Lin Jun Hao",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2015-07-19",
-        "name": "Lim Jun Hao",
-        "lastupdated": "2015-07-29",
-        "secondaryrace": ""
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "4999",
+        "source": "2",
+        "classification": "C",
+        "low": "4000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "1456789.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2016-12-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2016-11"
+          },
+          {
+            "date": "2016-12-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2016-12"
+          },
+          {
+            "date": "2016-12-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2016-12"
+          },
+          {
+            "date": "2017-01-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2016-12"
+          },
+          {
+            "date": "2017-01-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-01"
+          },
+          {
+            "date": "2017-01-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-01"
+          },
+          {
+            "date": "2017-02-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-01"
+          },
+          {
+            "date": "2017-02-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-02"
+          },
+          {
+            "date": "2017-02-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-02"
+          },
+          {
+            "date": "2017-03-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-02"
+          },
+          {
+            "date": "2017-03-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-03"
+          },
+          {
+            "date": "2017-03-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-03"
+          },
+          {
+            "date": "2017-04-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-03"
+          },
+          {
+            "date": "2017-04-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-04"
+          },
+          {
+            "date": "2017-04-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-04"
+          },
+          {
+            "date": "2017-05-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-04"
+          },
+          {
+            "date": "2017-05-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-05"
+          },
+          {
+            "date": "2017-05-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-05"
+          },
+          {
+            "date": "2017-06-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-05"
+          },
+          {
+            "date": "2017-06-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-06"
+          },
+          {
+            "date": "2017-06-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-06"
+          },
+          {
+            "date": "2017-07-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-06"
+          },
+          {
+            "date": "2017-07-12",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-07"
+          },
+          {
+            "date": "2017-07-21",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-07"
+          },
+          {
+            "date": "2017-08-01",
+            "employer": "Crystal Horse Invest Pte Ltd",
+            "amount": "500.00",
+            "month": "2017-07"
+          },
+          {
+            "date": "2017-08-12",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-08"
+          },
+          {
+            "date": "2017-08-21",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-08"
+          },
+          {
+            "date": "2017-09-01",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-08"
+          },
+          {
+            "date": "2017-09-12",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-09"
+          },
+          {
+            "date": "2017-09-21",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-09"
+          },
+          {
+            "date": "2017-10-01",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-09"
+          },
+          {
+            "date": "2017-10-12",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-10"
+          },
+          {
+            "date": "2017-10-21",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-10"
+          },
+          {
+            "date": "2017-11-01",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-10"
+          },
+          {
+            "date": "2017-11-12",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-11"
+          },
+          {
+            "date": "2017-11-21",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-11"
+          },
+          {
+            "date": "2017-12-01",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-11"
+          },
+          {
+            "date": "2017-12-12",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-12"
+          },
+          {
+            "date": "2017-12-21",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-12"
+          },
+          {
+            "date": "2018-01-01",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2017-12"
+          },
+          {
+            "date": "2018-01-12",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2018-01"
+          },
+          {
+            "date": "2018-01-21",
+            "employer": "Delta Marine Consultants PL",
+            "amount": "750.00",
+            "month": "2018-01"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "1581.48",
+        "source": "1",
+        "ma": "11470.70",
+        "classification": "C",
+        "sa": "21967.09"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
       }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "8"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1987"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS0713J",
-      "desc": "INNOVA JUNIOR COLLEGE"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "3999",
-      "source": "2",
-      "classification": "C",
-      "low": "3000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2456789.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    },  
+    "S9812382B": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "FREYA LIM GUO EN"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MRS FREYA LIM GUO EN"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "US"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1960-04-19"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "US"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "P"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E12345677F"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "367",
+        "street": "JURONG EAST STREET 21",
+        "lastupdated": "2018-03-20",
+        "block": "288A",
+        "source": "1",
+        "postal": "601288",
+        "classification": "C",
+        "floor": "08",
+        "building": "HDB-JURONG EAST"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "115"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "2"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "443172"
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2017-01-03"
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2014-11-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "529.00",
-          "month": "2014-10"
-        },
-        {
-          "date": "2015-01-18",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "951.00",
-          "month": "2014-12"
-        },
-        {
-          "date": "2014-10-19",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "526.00",
-          "month": "2014-10"
-        },
-        {
-          "date": "2014-12-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "541.00",
-          "month": "2014-12"
-        },
-        {
-          "date": "2015-03-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "590.00",
-          "month": "2015-02"
-        },
-        {
-          "date": "2015-02-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "1102.00",
-          "month": "2015-02"
-        },
-        {
-          "date": "2015-04-19",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "607.00",
-          "month": "2015-04"
-        },
-        {
-          "date": "2015-05-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "555.00",
-          "month": "2015-05"
-        },
-        {
-          "date": "2015-06-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "613.00",
-          "month": "2015-06"
-        },
-        {
-          "date": "2015-07-19",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "552.00",
-          "month": "2015-07"
-        },
-        {
-          "date": "2015-08-17",
-          "employer": "EMPLOYER DESCRIPTION : 0696080",
-          "amount": "1422.00",
-          "month": "2015-08"
+          "dialect": "TC",
+          "race": "CN",
+          "tob": "1045",
+          "sex": "M",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T1512909G",
+          "hanyupinyinname": "Lin Jun Hao",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2015-07-19",
+          "name": "Lim Jun Hao",
+          "lastupdated": "2015-07-29",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "8"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1987"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS0713J",
+        "desc": "INNOVA JUNIOR COLLEGE"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "3999",
+        "source": "2",
+        "classification": "C",
+        "low": "3000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2456789.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2014-11-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "529.00",
+            "month": "2014-10"
+          },
+          {
+            "date": "2015-01-18",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "951.00",
+            "month": "2014-12"
+          },
+          {
+            "date": "2014-10-19",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "526.00",
+            "month": "2014-10"
+          },
+          {
+            "date": "2014-12-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "541.00",
+            "month": "2014-12"
+          },
+          {
+            "date": "2015-03-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "590.00",
+            "month": "2015-02"
+          },
+          {
+            "date": "2015-02-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "1102.00",
+            "month": "2015-02"
+          },
+          {
+            "date": "2015-04-19",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "607.00",
+            "month": "2015-04"
+          },
+          {
+            "date": "2015-05-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "555.00",
+            "month": "2015-05"
+          },
+          {
+            "date": "2015-06-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "613.00",
+            "month": "2015-06"
+          },
+          {
+            "date": "2015-07-19",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "552.00",
+            "month": "2015-07"
+          },
+          {
+            "date": "2015-08-17",
+            "employer": "EMPLOYER DESCRIPTION : 0696080",
+            "amount": "1422.00",
+            "month": "2015-08"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "27857.35",
+        "source": "1",
+        "ma": "30635.84",
+        "classification": "C",
+        "sa": "90253.27"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "SFM8P"
+      }
     },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "27857.35",
-      "source": "1",
-      "ma": "30635.84",
-      "classification": "C",
-      "sa": "90253.27"
+    "S9812385G": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "DEWANARA VANASAMIN"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CLARISSA DEWANARA VANASAMIN"
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "DU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1950-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E23452346L"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "10",
+        "street": "SIMEI STREET 1",
+        "lastupdated": "2018-03-20",
+        "block": "138",
+        "postal": "520138",
+        "source": "1",
+        "classification": "C",
+        "floor": "38",
+        "building": "HDB-TAMPINES"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "postal": "",
+        "source": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "postal": "",
+        "source": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "115"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "7999",
+        "source": "2",
+        "classification": "C",
+        "low": "7000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "3456789.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2017"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2015-08-16",
+            "employer": "EMPLOYER DESCRIPTION : 3662454",
+            "amount": "563.00",
+            "month": "2015-07"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "2222.22",
+        "source": "1",
+        "ma": "2222.22",
+        "classification": "C",
+        "sa": "2222.22"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "EA123L"
+      }
     },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "SFM8P"
-    }
-  },
-  "S9812385G": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "DEWANARA VANASAMIN"
+    "S9812387C": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "HOWARD CHEN YU SHENG"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MR HOWARD CHEN YU SHENG"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1998-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E12345677F"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "SG",
+        "unit": "58",
+        "street": "PUNGGOL FIELD",
+        "lastupdated": "2016-01-06",
+        "block": "101B",
+        "source": "1",
+        "postal": "822101",
+        "classification": "C",
+        "floor": "05",
+        "building": "HDB-PUNGGOL"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "11111",
+        "street": "BUKIT BATOK STREET 11",
+        "lastupdated": "",
+        "block": "142",
+        "source": "",
+        "postal": "650142",
+        "classification": "",
+        "floor": "11",
+        "building": "HDB-BUKIT BATOK"
+      },
+      "billadd": {
+        "country": "",
+        "unit": "11111",
+        "street": "BUKIT BATOK STREET 11",
+        "lastupdated": "",
+        "block": "142",
+        "source": "",
+        "postal": "650142",
+        "classification": "",
+        "floor": "11",
+        "building": "HDB-BUKIT BATOK"
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "2016-01-06",
+        "source": "1",
+        "classification": "C",
+        "value": "114"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "3"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1976"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3006F",
+        "desc": "GAN ENG SENG SCHOOL"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "24133",
+        "desc": "FUND MANAGER"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "NEED ALL COMPANY"
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "3999",
+        "source": "2",
+        "classification": "C",
+        "low": "3000"
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "",
+        "source": "1",
+        "ma": "",
+        "classification": "C",
+        "sa": ""
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      }
     },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
+    "S9912363Z": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "CHENG QI FA"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CHEN QI FA"
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "ESTHER CHEN QI FA"
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "U"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "KE"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1999-10-06"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "P"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E3546387W"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "22",
+        "street": "LORONG 1 TOA PAYOH",
+        "lastupdated": "",
+        "block": "123",
+        "source": "1",
+        "postal": "310123",
+        "classification": "C",
+        "floor": "12",
+        "building": "TOA PAYOH VIEW"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "113"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "84567.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2016"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2614-12-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2014-12"
+          },
+          {
+            "date": "2615-01-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-01"
+          },
+          {
+            "date": "2615-02-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-02"
+          },
+          {
+            "date": "2615-03-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-03"
+          },
+          {
+            "date": "2615-04-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-04"
+          },
+          {
+            "date": "2615-05-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-05"
+          },
+          {
+            "date": "2615-06-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-06"
+          },
+          {
+            "date": "2615-07-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-07"
+          },
+          {
+            "date": "2615-08-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-08"
+          },
+          {
+            "date": "2615-09-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-09"
+          },
+          {
+            "date": "2615-10-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-10"
+          },
+          {
+            "date": "2615-11-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-11"
+          },
+          {
+            "date": "2615-12-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2015-12"
+          },
+          {
+            "date": "2616-01-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "1582.20",
+            "month": "2016-01"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "141234.00",
+        "source": "1",
+        "ma": "30213.00",
+        "classification": "C",
+        "sa": "45123.00"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "SBA6543K"
+      }
     },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CLARISSA DEWANARA VANASAMIN"
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "DU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1950-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E23452346L"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "10",
-      "street": "SIMEI STREET 1",
-      "lastupdated": "2018-03-20",
-      "block": "138",
-      "postal": "520138",
-      "source": "1",
-      "classification": "C",
-      "floor": "38",
-      "building": "HDB-TAMPINES"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "postal": "",
-      "source": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "postal": "",
-      "source": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "115"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "7999",
-      "source": "2",
-      "classification": "C",
-      "low": "7000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "3456789.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2017"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    "S9912372I": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "TOMMY S/O BALA"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "TOMMY"
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MR TOMMY"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "IN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "CD"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1999-10-07"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "IN"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "P"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "22",
+        "street": "LORONG 1 TOA PAYOH",
+        "lastupdated": "",
+        "block": "123",
+        "source": "1",
+        "postal": "310123",
+        "classification": "C",
+        "floor": "12",
+        "building": "TOA PAYOH VIEW"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "113"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "5"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2011-02-15"
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2015-08-16",
-          "employer": "EMPLOYER DESCRIPTION : 3662454",
-          "amount": "563.00",
-          "month": "2015-07"
+          "dialect": "",
+          "race": "",
+          "tob": "",
+          "sex": "",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8512345Y",
+          "hanyupinyinname": "",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "",
+          "name": "",
+          "lastupdated": "1985-08-15",
+          "secondaryrace": ""
+        },
+        {
+          "dialect": "",
+          "race": "",
+          "tob": "",
+          "sex": "",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8702311K",
+          "hanyupinyinname": "",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "",
+          "name": "",
+          "lastupdated": "1999-01-11",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "2222.22",
-      "source": "1",
-      "ma": "2222.22",
-      "classification": "C",
-      "sa": "2222.22"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "EA123L"
-    }
-  },
-  "S9812387C": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "HOWARD CHEN YU SHENG"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MR HOWARD CHEN YU SHENG"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1998-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E12345677F"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "SG",
-      "unit": "58",
-      "street": "PUNGGOL FIELD",
-      "lastupdated": "2016-01-06",
-      "block": "101B",
-      "source": "1",
-      "postal": "822101",
-      "classification": "C",
-      "floor": "05",
-      "building": "HDB-PUNGGOL"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "11111",
-      "street": "BUKIT BATOK STREET 11",
-      "lastupdated": "",
-      "block": "142",
-      "source": "",
-      "postal": "650142",
-      "classification": "",
-      "floor": "11",
-      "building": "HDB-BUKIT BATOK"
-    },
-    "billadd": {
-      "country": "",
-      "unit": "11111",
-      "street": "BUKIT BATOK STREET 11",
-      "lastupdated": "",
-      "block": "142",
-      "source": "",
-      "postal": "650142",
-      "classification": "",
-      "floor": "11",
-      "building": "HDB-BUKIT BATOK"
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "2016-01-06",
-      "source": "1",
-      "classification": "C",
-      "value": "114"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "3"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1976"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3006F",
-      "desc": "GAN ENG SENG SCHOOL"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "24133",
-      "desc": "FUND MANAGER"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "NEED ALL COMPANY"
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "3999",
-      "source": "2",
-      "classification": "C",
-      "low": "3000"
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "",
-      "source": "1",
-      "ma": "",
-      "classification": "C",
-      "sa": ""
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "S9912363Z": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "CHENG QI FA"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CHEN QI FA"
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "ESTHER CHEN QI FA"
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "U"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "KE"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1999-10-06"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "P"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E3546387W"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "22",
-      "street": "LORONG 1 TOA PAYOH",
-      "lastupdated": "",
-      "block": "123",
-      "source": "1",
-      "postal": "310123",
-      "classification": "C",
-      "floor": "12",
-      "building": "TOA PAYOH VIEW"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "113"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "84567.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2016"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "4"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "2001"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "",
+        "desc": "UNIVERSITY"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "11121",
+        "desc": "SENIOR GOVERNMENT OFFICIAL"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "75000.00"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2016"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [
+          {
+            "date": "2614-12-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2014-12"
+          },
+          {
+            "date": "2615-01-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-01"
+          },
+          {
+            "date": "2615-02-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-02"
+          },
+          {
+            "date": "2615-03-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-03"
+          },
+          {
+            "date": "2615-04-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-04"
+          },
+          {
+            "date": "2615-05-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-05"
+          },
+          {
+            "date": "2615-06-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-06"
+          },
+          {
+            "date": "2615-07-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-07"
+          },
+          {
+            "date": "2615-08-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-08"
+          },
+          {
+            "date": "2615-09-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-09"
+          },
+          {
+            "date": "2615-10-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-10"
+          },
+          {
+            "date": "2615-11-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-11"
+          },
+          {
+            "date": "2615-12-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2015-12"
+          },
+          {
+            "date": "2616-01-28",
+            "employer": "CLEAR LINK PTE LTD",
+            "amount": "2866.99",
+            "month": "2016-01"
+          }
+        ],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "0.00",
+        "source": "1",
+        "ma": "0.00",
+        "classification": "C",
+        "sa": "0.00"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      }
+    },
+    "S6005053H": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MY,INFO%BB"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "HANYUD12"
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MYINFOALIAS D"
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1948-09-10"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E2345234FDFEW9874326LO"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2025-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "112",
+        "street": "BUKIT BATOK STREET 25",
+        "lastupdated": "",
+        "block": "289C",
+        "source": "1",
+        "postal": "652289",
+        "classification": "C",
+        "floor": "02",
+        "building": "NATURE VIEW"
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "115"
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "5"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "2011-02-15"
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "N"
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "oa": "12345.00",
+        "ma": "76987.00",
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "sa": "73627.00",
+        "ra": "32864.00"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": "SFH2K"
+      }
+    },
+    "S6005055D": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MY.INFO:CC"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "HANYUEE"
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MYINFOALIAS E"
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "NAMEG"
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SK"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "IN"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1948-02-01"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E12345677F"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "1999-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "",
+        "street": "KG SG RAMAL LUAR",
+        "lastupdated": "",
+        "block": "75",
+        "source": "1",
+        "postal": "43000",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "53201",
+        "desc": ""
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "NA"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "oa": "39827.32",
+        "ma": "54353.23",
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "sa": "54353.88",
+        "ra": "34265.64"
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      }
+    },
+    "G1612348Q": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "ALFONSO CRUZ"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "EU"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "AU"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1992-02-01"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "AU"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E12348742J"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2023-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "1",
+        "postal": "",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "N"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "1"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [],
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "13304",
+        "desc": "IT SERVICE MANAGER"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "UBI COMPUTER SYSTEMS PTE. LTD."
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "Live"
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "2019-12-31"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "123437.12"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "",
+        "source": "1",
+        "ma": "",
+        "classification": "C",
+        "sa": ""
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      }
+    },
+    "G1612349N": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "ALFRED CHONG BOON HAO"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "M"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1948-12-11"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": "E43278273K"
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "2024-01-01"
+      },
+      "regadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "1",
+        "postal": "",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "342",
+        "street": "HOUGANG AVENUE 1",
+        "lastupdated": "2018-03-21",
+        "block": "238",
+        "source": "2",
+        "postal": "530238",
+        "classification": "C",
+        "floor": "04",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "2"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "AL6980131721"
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "ID"
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "1992-03-21"
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2614-12-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2014-12"
+          "dialect": "",
+          "race": "",
+          "tob": "",
+          "sex": "",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8501177J",
+          "hanyupinyinname": "",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "",
+          "name": "",
+          "lastupdated": "2005-07-12",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-01-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-01"
-        },
-        {
-          "date": "2615-02-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-02"
-        },
-        {
-          "date": "2615-03-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-03"
-        },
-        {
-          "date": "2615-04-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-04"
-        },
-        {
-          "date": "2615-05-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-05"
-        },
-        {
-          "date": "2615-06-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-06"
-        },
-        {
-          "date": "2615-07-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-07"
-        },
-        {
-          "date": "2615-08-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-08"
-        },
-        {
-          "date": "2615-09-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-09"
-        },
-        {
-          "date": "2615-10-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-10"
-        },
-        {
-          "date": "2615-11-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-11"
-        },
-        {
-          "date": "2615-12-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2015-12"
-        },
-        {
-          "date": "2616-01-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "1582.20",
-          "month": "2016-01"
+          "dialect": "TC",
+          "race": "CN",
+          "tob": "1208",
+          "sex": "M",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "T0512909G",
+          "hanyupinyinname": "Zhang Jun Hao",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "2005-07-12",
+          "name": "Chong Jun Hao",
+          "lastupdated": "2005-07-12",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "141234.00",
-      "source": "1",
-      "ma": "30213.00",
-      "classification": "C",
-      "sa": "45123.00"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "SBA6543K"
-    }
-  },
-  "S9912372I": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "TOMMY S/O BALA"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "TOMMY"
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MR TOMMY"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "IN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "CD"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1999-10-07"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "IN"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "P"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "22",
-      "street": "LORONG 1 TOA PAYOH",
-      "lastupdated": "",
-      "block": "123",
-      "source": "1",
-      "postal": "310123",
-      "classification": "C",
-      "floor": "12",
-      "building": "TOA PAYOH VIEW"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "113"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "5"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2011-02-15"
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "",
-        "race": "",
-        "tob": "",
-        "sex": "",
-        "source": "1",
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
         "classification": "C",
-        "birthcertno": "S8512345Y",
-        "hanyupinyinname": "",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "",
-        "name": "",
-        "lastupdated": "1985-08-15",
-        "secondaryrace": ""
+        "value": "7"
       },
-      {
-        "dialect": "",
-        "race": "",
-        "tob": "",
-        "sex": "",
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "1987"
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "NTU",
+        "desc": "NANYANG TECHNOLOGICAL UNIVERSITY"
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "13292",
+        "desc": "SENIOR MANAGER, QUALITY ASSURANCE"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "JAPAN <CIRCUIT> INDUS / TRIAL CO., LTD."
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
         "source": "1",
         "classification": "C",
-        "birthcertno": "S8702311K",
-        "hanyupinyinname": "",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "",
-        "name": "",
-        "lastupdated": "1999-01-11",
-        "secondaryrace": ""
+        "value": "Live"
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "2019-12-31"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "",
+        "source": "1",
+        "ma": "",
+        "classification": "C",
+        "sa": ""
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
       }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "4"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "2001"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "",
-      "desc": "UNIVERSITY"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "11121",
-      "desc": "SENIOR GOVERNMENT OFFICIAL"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "75000.00"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2016"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [
+    },  
+    "G1612350T": {
+      "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "JENNY LIM WAI FOOK"
+      },
+      "hanyupinyinname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "aliasname": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hanyupinyinaliasname": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "marriedname": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+      },
+      "race": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "CN"
+      },
+      "secondaryrace": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "dialect": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1992-02-01"
+      },
+      "birthcountry": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "MY"
+      },
+      "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportnumber": {
+        "lastupdated": "2018-08-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "passportexpirydate": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "regadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "1",
+        "postal": "",
+        "classification": "C",
+        "floor": "",
+        "building": ""
+      },
+      "mailadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "billadd": {
+        "country": "",
+        "unit": "",
+        "street": "",
+        "lastupdated": "",
+        "block": "",
+        "source": "",
+        "postal": "",
+        "classification": "",
+        "floor": "",
+        "building": ""
+      },
+      "housingtype": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "hdbtype": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "ownerprivate": {
+        "lastupdated": "2017-04-26",
+        "source": "1",
+        "classification": "C",
+        "value": "Y"
+      },
+      "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+      },
+      "homeno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "2",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "69876543"
+      },
+      "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+      },
+      "marital": {
+        "lastupdated": "2018-03-21",
+        "source": "1",
+        "classification": "C",
+        "value": "2"
+      },
+      "marriagecertno": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "560123"
+      },
+      "countryofmarriage": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+      },
+      "marriagedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": "1992-03-21"
+      },
+      "divorcedate": {
+        "lastupdated": "",
+        "source": "1",
+        "classification": "C",
+        "value": ""
+      },
+      "childrenbirthrecords": [
         {
-          "date": "2614-12-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2014-12"
+          "dialect": "",
+          "race": "",
+          "tob": "",
+          "sex": "",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8501177J",
+          "hanyupinyinname": "",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "",
+          "name": "",
+          "lastupdated": "2005-07-12",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-01-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-01"
+          "dialect": "",
+          "race": "",
+          "tob": "",
+          "sex": "",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8310088L",
+          "hanyupinyinname": "",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "",
+          "name": "",
+          "lastupdated": "1983-03-21",
+          "secondaryrace": ""
         },
         {
-          "date": "2615-02-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-02"
-        },
-        {
-          "date": "2615-03-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-03"
-        },
-        {
-          "date": "2615-04-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-04"
-        },
-        {
-          "date": "2615-05-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-05"
-        },
-        {
-          "date": "2615-06-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-06"
-        },
-        {
-          "date": "2615-07-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-07"
-        },
-        {
-          "date": "2615-08-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-08"
-        },
-        {
-          "date": "2615-09-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-09"
-        },
-        {
-          "date": "2615-10-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-10"
-        },
-        {
-          "date": "2615-11-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-11"
-        },
-        {
-          "date": "2615-12-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2015-12"
-        },
-        {
-          "date": "2616-01-28",
-          "employer": "CLEAR LINK PTE LTD",
-          "amount": "2866.99",
-          "month": "2016-01"
+          "dialect": "",
+          "race": "",
+          "tob": "",
+          "sex": "",
+          "source": "1",
+          "classification": "C",
+          "birthcertno": "S8119988A",
+          "hanyupinyinname": "",
+          "hanyupinyinaliasname": "",
+          "marriedname": "",
+          "aliasname": "",
+          "dob": "",
+          "name": "",
+          "lastupdated": "1981-02-10",
+          "secondaryrace": ""
         }
       ],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "0.00",
-      "source": "1",
-      "ma": "0.00",
-      "classification": "C",
-      "sa": "0.00"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "S6005053H": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MY,INFO%BB"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "HANYUD12"
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MYINFOALIAS D"
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1948-09-10"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E2345234FDFEW9874326LO"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2025-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "112",
-      "street": "BUKIT BATOK STREET 25",
-      "lastupdated": "",
-      "block": "289C",
-      "source": "1",
-      "postal": "652289",
-      "classification": "C",
-      "floor": "02",
-      "building": "NATURE VIEW"
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "115"
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "5"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "2011-02-15"
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "N"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "oa": "12345.00",
-      "ma": "76987.00",
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "sa": "73627.00",
-      "ra": "32864.00"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": "SFH2K"
-    }
-  },
-  "S6005055D": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MY.INFO:CC"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "HANYUEE"
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MYINFOALIAS E"
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "NAMEG"
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SK"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "IN"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1948-02-01"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "C"
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E12345677F"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "1999-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "",
-      "street": "KG SG RAMAL LUAR",
-      "lastupdated": "",
-      "block": "75",
-      "source": "1",
-      "postal": "43000",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "53201",
-      "desc": ""
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "NA"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "oa": "39827.32",
-      "ma": "54353.23",
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "sa": "54353.88",
-      "ra": "34265.64"
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "G1612348Q": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "ALFONSO CRUZ"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "EU"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "AU"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1992-02-01"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "AU"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E12348742J"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2023-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "1",
-      "postal": "",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "N"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "1"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "13304",
-      "desc": "IT SERVICE MANAGER"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "UBI COMPUTER SYSTEMS PTE. LTD."
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "Live"
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "2019-12-31"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "123437.12"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "",
-      "source": "1",
-      "ma": "",
-      "classification": "C",
-      "sa": ""
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },
-  "G1612349N": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "ALFRED CHONG BOON HAO"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "M"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1948-12-11"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": "E43278273K"
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "2024-01-01"
-    },
-    "regadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "1",
-      "postal": "",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "342",
-      "street": "HOUGANG AVENUE 1",
-      "lastupdated": "2018-03-21",
-      "block": "238",
-      "source": "2",
-      "postal": "530238",
-      "classification": "C",
-      "floor": "04",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "2"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "AL6980131721"
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "ID"
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "1992-03-21"
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "",
-        "race": "",
-        "tob": "",
-        "sex": "",
-        "source": "1",
+      "edulevel": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
         "classification": "C",
-        "birthcertno": "S8501177J",
-        "hanyupinyinname": "",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "",
-        "name": "",
-        "lastupdated": "2005-07-12",
-        "secondaryrace": ""
+        "value": ""
       },
-      {
-        "dialect": "TC",
-        "race": "CN",
-        "tob": "1208",
-        "sex": "M",
+      "gradyear": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": ""
+      },
+      "schoolname": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "T07GS3011J",
+        "desc": ""
+      },
+      "occupation": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "",
+        "desc": "CLERICAL ASSISTANT"
+      },
+      "employment": {
+        "lastupdated": "2017-10-11",
+        "source": "2",
+        "classification": "C",
+        "value": "CST CONTAINER SERVICES PTE LTD"
+      },
+      "workpassstatus": {
+        "lastupdated": "2018-03-02",
         "source": "1",
         "classification": "C",
-        "birthcertno": "T0512909G",
-        "hanyupinyinname": "Zhang Jun Hao",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "2005-07-12",
-        "name": "Chong Jun Hao",
-        "lastupdated": "2005-07-12",
-        "secondaryrace": ""
+        "value": "Live"
+      },
+      "workpassexpirydate": {
+        "lastupdated": "2018-03-02",
+        "source": "1",
+        "classification": "C",
+        "value": "2019-12-31"
+      },
+      "householdincome": {
+        "lastupdated": "2017-10-24",
+        "high": "",
+        "source": "2",
+        "classification": "C",
+        "low": ""
+      },
+      "assessableincome": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "170402.02"
+      },
+      "assessyear": {
+        "lastupdated": "2017-03-16",
+        "source": "1",
+        "classification": "C",
+        "value": "2018"
+      },
+      "cpfcontributions": {
+        "lastupdated": "2017-03-16",
+        "cpfcontribution": [],
+        "source": "1",
+        "classification": "C"
+      },
+      "cpfbalances": {
+        "lastupdated": "2018-08-23",
+        "oa": "",
+        "source": "1",
+        "ma": "",
+        "classification": "C",
+        "sa": ""
+      },
+      "vehno": {
+        "lastupdated": "",
+        "source": "2",
+        "classification": "C",
+        "value": ""
       }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "7"
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "1987"
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "NTU",
-      "desc": "NANYANG TECHNOLOGICAL UNIVERSITY"
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "13292",
-      "desc": "SENIOR MANAGER, QUALITY ASSURANCE"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "JAPAN <CIRCUIT> INDUS / TRIAL CO., LTD."
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "Live"
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "2019-12-31"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "",
-      "source": "1",
-      "ma": "",
-      "classification": "C",
-      "sa": ""
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    }
-  },  
-  "G1612350T": {
-    "name": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "JENNY LIM WAI FOOK"
-    },
-    "hanyupinyinname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "aliasname": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hanyupinyinaliasname": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "marriedname": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "sex": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "F"
-    },
-    "race": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "CN"
-    },
-    "secondaryrace": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "dialect": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "nationality": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "dob": {
-      "lastupdated": "2018-03-20",
-      "source": "1",
-      "classification": "C",
-      "value": "1992-02-01"
-    },
-    "birthcountry": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": "MY"
-    },
-    "residentialstatus": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportnumber": {
-      "lastupdated": "2018-08-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "passportexpirydate": {
-      "lastupdated": "2018-03-23",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "regadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "1",
-      "postal": "",
-      "classification": "C",
-      "floor": "",
-      "building": ""
-    },
-    "mailadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "billadd": {
-      "country": "",
-      "unit": "",
-      "street": "",
-      "lastupdated": "",
-      "block": "",
-      "source": "",
-      "postal": "",
-      "classification": "",
-      "floor": "",
-      "building": ""
-    },
-    "housingtype": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "hdbtype": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "ownerprivate": {
-      "lastupdated": "2017-04-26",
-      "source": "1",
-      "classification": "C",
-      "value": "Y"
-    },
-    "email": {
-      "lastupdated": "2018-08-23",
-      "source": "4",
-      "classification": "C",
-      "value": "myinfotesting@gmail.com"
-    },
-    "homeno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "2",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "69876543"
-    },
-    "mobileno": {
-      "lastupdated": "2018-08-23",
-      "code": "65",
-      "source": "4",
-      "classification": "C",
-      "prefix": "+",
-      "nbr": "97399245"
-    },
-    "marital": {
-      "lastupdated": "2018-03-21",
-      "source": "1",
-      "classification": "C",
-      "value": "2"
-    },
-    "marriagecertno": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "560123"
-    },
-    "countryofmarriage": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "SG"
-    },
-    "marriagedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": "1992-03-21"
-    },
-    "divorcedate": {
-      "lastupdated": "",
-      "source": "1",
-      "classification": "C",
-      "value": ""
-    },
-    "childrenbirthrecords": [
-      {
-        "dialect": "",
-        "race": "",
-        "tob": "",
-        "sex": "",
-        "source": "1",
-        "classification": "C",
-        "birthcertno": "S8501177J",
-        "hanyupinyinname": "",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "",
-        "name": "",
-        "lastupdated": "2005-07-12",
-        "secondaryrace": ""
-      },
-      {
-        "dialect": "",
-        "race": "",
-        "tob": "",
-        "sex": "",
-        "source": "1",
-        "classification": "C",
-        "birthcertno": "S8310088L",
-        "hanyupinyinname": "",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "",
-        "name": "",
-        "lastupdated": "1983-03-21",
-        "secondaryrace": ""
-      },
-      {
-        "dialect": "",
-        "race": "",
-        "tob": "",
-        "sex": "",
-        "source": "1",
-        "classification": "C",
-        "birthcertno": "S8119988A",
-        "hanyupinyinname": "",
-        "hanyupinyinaliasname": "",
-        "marriedname": "",
-        "aliasname": "",
-        "dob": "",
-        "name": "",
-        "lastupdated": "1981-02-10",
-        "secondaryrace": ""
-      }
-    ],
-    "edulevel": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "gradyear": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": ""
-    },
-    "schoolname": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "T07GS3011J",
-      "desc": ""
-    },
-    "occupation": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "",
-      "desc": "CLERICAL ASSISTANT"
-    },
-    "employment": {
-      "lastupdated": "2017-10-11",
-      "source": "2",
-      "classification": "C",
-      "value": "CST CONTAINER SERVICES PTE LTD"
-    },
-    "workpassstatus": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "Live"
-    },
-    "workpassexpirydate": {
-      "lastupdated": "2018-03-02",
-      "source": "1",
-      "classification": "C",
-      "value": "2019-12-31"
-    },
-    "householdincome": {
-      "lastupdated": "2017-10-24",
-      "high": "",
-      "source": "2",
-      "classification": "C",
-      "low": ""
-    },
-    "assessableincome": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "170402.02"
-    },
-    "assessyear": {
-      "lastupdated": "2017-03-16",
-      "source": "1",
-      "classification": "C",
-      "value": "2018"
-    },
-    "cpfcontributions": {
-      "lastupdated": "2017-03-16",
-      "cpfcontribution": [],
-      "source": "1",
-      "classification": "C"
-    },
-    "cpfbalances": {
-      "lastupdated": "2018-08-23",
-      "oa": "",
-      "source": "1",
-      "ma": "",
-      "classification": "C",
-      "sa": ""
-    },
-    "vehno": {
-      "lastupdated": "",
-      "source": "2",
-      "classification": "C",
-      "value": ""
     }
   }
 }

--- a/static/myinfo.json
+++ b/static/myinfo.json
@@ -1,0 +1,6103 @@
+{
+  "S9912369I": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "PATRICIA KIM WAI MUN"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MRS PATRICIA KIM WAI MUN"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MX"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1999-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E1234577F"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2020-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "11",
+      "street": "BEDOK RESERVOIR ROAD",
+      "lastupdated": "2018-03-20",
+      "block": "113",
+      "source": "1",
+      "postal": "470113",
+      "classification": "C",
+      "floor": "03",
+      "building": "EUNOS VISTA"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "114"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "2"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "901889"
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2012-02-15"
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "HK",
+        "race": "CN",
+        "tob": "0901",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S5562882C",
+        "hanyupinyinname": "Cheng Pei Ni",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2011-09-10",
+        "name": "Jo Tan Pei Ni",
+        "lastupdated": "2018-05-16",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "HK",
+        "race": "CN",
+        "tob": "2021",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8816582I",
+        "hanyupinyinname": "Cheng Wei Ling",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2015-07-18",
+        "name": "Joyce Tan Wei Ling",
+        "lastupdated": "2018-05-16",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "HK",
+        "race": "CN",
+        "tob": "0901",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T0202564C",
+        "hanyupinyinname": "Cheng Shu Hui",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2012-09-10",
+        "name": "Joycelyn Tan Shu Hui",
+        "lastupdated": "2018-05-16",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "9"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "2001"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "NTU",
+      "desc": "NANYANG TECHNOLOGICAL UNIVERSITY"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "13304",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "AAS Sistemas Pte Ltd"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "above",
+      "source": "2",
+      "classification": "C",
+      "low": "2000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "923456789.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2614-12-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2014-12"
+        },
+        {
+          "date": "2615-01-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-01"
+        },
+        {
+          "date": "2615-02-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-02"
+        },
+        {
+          "date": "2615-03-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-03"
+        },
+        {
+          "date": "2615-04-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-04"
+        },
+        {
+          "date": "2615-05-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-05"
+        },
+        {
+          "date": "2615-06-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-06"
+        },
+        {
+          "date": "2615-07-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-07"
+        },
+        {
+          "date": "2615-08-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-08"
+        },
+        {
+          "date": "2615-09-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-09"
+        },
+        {
+          "date": "2615-10-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-10"
+        },
+        {
+          "date": "2615-11-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-11"
+        },
+        {
+          "date": "2615-12-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2015-12"
+        },
+        {
+          "date": "2616-01-28",
+          "employer": "AAS SISTEMAS PTE LTD",
+          "amount": "5626.67",
+          "month": "2016-01"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2017-03-16",
+      "oa": "1581.48",
+      "source": "1",
+      "ma": "21967.09",
+      "classification": "C",
+      "sa": "11470.70"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "SKK789T"
+    }
+  },
+  "S9912370B": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "ELIZABERTH PIERCE JOHNSON"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MRS ELIZABERTH PIERCE JOHNSON"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1999-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E3546374W"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2023-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "",
+      "street": "ROCHDALE ROAD",
+      "lastupdated": "2018-03-20",
+      "block": "29",
+      "source": "1",
+      "postal": "535842",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "SG",
+      "unit": "1234",
+      "street": "ANG MO KIO AVENUE 5",
+      "lastupdated": "2018-03-20",
+      "block": "154",
+      "source": "2",
+      "postal": "560154",
+      "classification": "C",
+      "floor": "12",
+      "building": "YIO CHU KANG GROVE"
+    },
+    "billadd": {
+      "country": "",
+      "unit": "11",
+      "street": "ANG MO KIO AVENUE 5",
+      "lastupdated": "2018-03-20",
+      "block": "153",
+      "source": "2",
+      "postal": "560153",
+      "classification": "",
+      "floor": "10",
+      "building": "YIO CHU KANG GROVE"
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "122"
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "Y"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "3"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {}
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "2001"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS0701A",
+      "desc": "NATIONAL JUNIOR COLLEGE"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "12123",
+      "desc": "TRAINING MANAGER"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "balik kampung pte ltd"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "1999",
+      "source": "2",
+      "classification": "C",
+      "low": "1000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2614-12-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2014-12"
+        },
+        {
+          "date": "2615-01-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-01"
+        },
+        {
+          "date": "2615-02-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-02"
+        },
+        {
+          "date": "2615-03-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-03"
+        },
+        {
+          "date": "2615-04-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-04"
+        },
+        {
+          "date": "2615-05-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-05"
+        },
+        {
+          "date": "2615-06-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-06"
+        },
+        {
+          "date": "2615-07-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-07"
+        },
+        {
+          "date": "2615-08-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-08"
+        },
+        {
+          "date": "2615-09-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-09"
+        },
+        {
+          "date": "2615-10-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-10"
+        },
+        {
+          "date": "2615-11-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-11"
+        },
+        {
+          "date": "2615-12-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2015-12"
+        },
+        {
+          "date": "2616-01-28",
+          "employer": "BALIK KAMPUNG PTE LTD",
+          "amount": "1865.21",
+          "month": "2016-01"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "0.00",
+      "source": "1",
+      "ma": "0.00",
+      "classification": "C",
+      "sa": "0.00"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "SJY1234R"
+    }
+  },
+  "S9912374E": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "TIMOTHY TAN CHENG GUAN"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CHEN CHENG GUAN, TIMOTHY"
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "US"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "GN"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1990-04-19"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "US"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "P"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E1234567F"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2024-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "367",
+      "street": "JURONG EAST AVENUE 1",
+      "lastupdated": "2018-03-20",
+      "block": "35",
+      "postal": "609774",
+      "source": "1",
+      "classification": "C",
+      "floor": "08",
+      "building": "PARC OASIS"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "postal": "",
+      "source": "",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "postal": "",
+      "source": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "131"
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "2"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "810203"
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "1990-02-15"
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "",
+        "race": "CN",
+        "tob": "0901",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1401234A",
+        "hanyupinyinname": "Cheng Yi Sheng",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2014-03-10",
+        "name": "Anthony Tan Yi Sheng",
+        "lastupdated": "2014-03-10",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "",
+        "race": "CN",
+        "tob": "1828",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1519876K",
+        "hanyupinyinname": "Cheng Li Yin",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2015-05-12",
+        "name": "Melody Tan Li Yin",
+        "lastupdated": "2015-05-12",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "7"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "2001"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS0805J",
+      "desc": "NANYANG JUNIOR COLLEGE"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "21453",
+      "desc": "CHEMICAL ENGINEER (PETROCHEMICALS)"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "front pal chemicals pte ltd"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "3999",
+      "source": "2",
+      "classification": "C",
+      "low": "3000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2456789"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2614-12-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2014-12"
+        },
+        {
+          "date": "2615-01-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-01"
+        },
+        {
+          "date": "2615-02-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-02"
+        },
+        {
+          "date": "2615-03-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-03"
+        },
+        {
+          "date": "2615-04-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-04"
+        },
+        {
+          "date": "2615-05-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-05"
+        },
+        {
+          "date": "2615-06-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-06"
+        },
+        {
+          "date": "2615-07-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-07"
+        },
+        {
+          "date": "2615-08-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-08"
+        },
+        {
+          "date": "2615-09-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-09"
+        },
+        {
+          "date": "2615-10-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-10"
+        },
+        {
+          "date": "2615-11-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-11"
+        },
+        {
+          "date": "2615-12-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2015-12"
+        },
+        {
+          "date": "2616-01-28",
+          "employer": "EYEWEAR OPTICS PTE LTD",
+          "amount": "4965.92",
+          "month": "2016-01"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "27857.35",
+      "source": "1",
+      "ma": "90253.27",
+      "classification": "C",
+      "sa": "30635.84"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "S9912366D":{
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "FATIMAH"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1980-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E4645364P"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "12",
+      "street": "BRADDELL HILL",
+      "lastupdated": "2018-03-20",
+      "block": "10",
+      "source": "1",
+      "postal": "579719",
+      "classification": "C",
+      "floor": "23",
+      "building": "BRADDELL VIEW"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "139"
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "5"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2011-02-28"
+    },
+    "childrenbirthrecords": [
+      {}
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "0.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "0.00",
+      "source": "1",
+      "ma": "0.00",
+      "classification": "C",
+      "sa": "0.00"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "SBA9988K"
+    }
+  },
+  "F1612347K": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "TAN AH HONG"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1960-05-17"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "2018-03-20",
+      "block": "",
+      "source": "1",
+      "postal": "",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "SG",
+      "unit": "12413",
+      "street": "BEDOK NORTH ROAD",
+      "lastupdated": "2018-08-23",
+      "block": "180",
+      "source": "2",
+      "postal": "460180",
+      "classification": "",
+      "floor": "12",
+      "building": "VISTA 8"
+    },
+    "billadd": {
+      "country": "SG",
+      "unit": "12413",
+      "street": "BEDOK NORTH ROAD",
+      "lastupdated": "2018-08-23",
+      "block": "180",
+      "source": "2",
+      "postal": "460180",
+      "classification": "",
+      "floor": "12",
+      "building": "VISTA 8"
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "Y"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "",
+      "desc": "OPERATION MANAGER"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "MULTI GRIP MARINE ENGRG"
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "Live"
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "2019-12-31"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "7999",
+      "source": "2",
+      "classification": "C",
+      "low": "7000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "323456789"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "",
+      "source": "1",
+      "ma": "",
+      "classification": "C",
+      "sa": ""
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "G1612352N": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "AMY CHONG GAN CHENG"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "AR"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "TH"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1961-06-17"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "US"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E3546387W"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "2018-03-20",
+      "block": "",
+      "source": "1",
+      "postal": "",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "SG",
+      "unit": "123",
+      "street": "BEDOK RESERVOIR ROAD",
+      "lastupdated": "2018-08-23",
+      "block": "613B",
+      "source": "2",
+      "postal": "472613",
+      "classification": "",
+      "floor": "05",
+      "building": "HDB-BEDOK"
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "2"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "290229"
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2017-01-03"
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "CT",
+        "race": "CN",
+        "tob": "1419",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1203367F",
+        "hanyupinyinname": "Zheng Xue Ling",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2012-01-12",
+        "name": "Tay Xue Ling, Christina",
+        "lastupdated": "2012-01-12",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "CT",
+        "race": "CN",
+        "tob": "1956",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1316755J",
+        "hanyupinyinname": "Zheng Xue Wei",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2013-07-18",
+        "name": "Tay Xue Wei, Michelle",
+        "lastupdated": "2013-07-19",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "CT",
+        "race": "CN",
+        "tob": "1601",
+        "sex": "M",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1502351D",
+        "hanyupinyinname": "Zheng Wei Ming",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2015-11-20",
+        "name": "Tay Wei Ming, Ronaldo",
+        "lastupdated": "2015-11-20",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "CT",
+        "race": "CN",
+        "tob": "2200",
+        "sex": "M",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1710092H",
+        "hanyupinyinname": "Zheng Wei Qiang",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2017-07-18",
+        "name": "Tay Wei Qiang, Messi",
+        "lastupdated": "2017-07-19",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "7"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "2011"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS0705G",
+      "desc": "ANDERSON JUNIOR COLLEGE"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "13304",
+      "desc": "IT SERVICE MANAGER"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "AH HUAT PTE LTD"
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "Live"
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "2019-12-31"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "0.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "",
+      "source": "1",
+      "ma": "",
+      "classification": "C",
+      "sa": ""
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "S9812379B": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "LIM YONG XIANG"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "LIN YONG XIANG"
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "JASCKSON LIM YONG XIANG"
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "JASCKSON LIN YONG XIANG"
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MR LIM YONG XIANG"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "GC"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1980-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "P"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "22",
+      "street": "LORONG 1 TOA PAYOH",
+      "lastupdated": "2018-03-20",
+      "block": "123",
+      "source": "1",
+      "postal": "310123",
+      "classification": "C",
+      "floor": "12",
+      "building": "TOA PAYOH VIEW"
+    },
+    "mailadd": {
+      "country": "SG",
+      "unit": "1234",
+      "street": "ANG MO KIO AVENUE 5",
+      "lastupdated": "2018-08-23",
+      "block": "154",
+      "source": "2",
+      "postal": "560154",
+      "classification": "",
+      "floor": "12",
+      "building": "YIO CHU KANG GROVE"
+    },
+    "billadd": {
+      "country": "",
+      "unit": "11",
+      "street": "ANG MO KIO AVENUE 5",
+      "lastupdated": "2018-08-23",
+      "block": "153",
+      "source": "2",
+      "postal": "560153",
+      "classification": "",
+      "floor": "10",
+      "building": "YIO CHU KANG GROVE"
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "113"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "5"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2015-01-01"
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "8"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1952"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T12GS0005D",
+      "desc": "SPRINGDALE PRIMARY SCHOOL"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "11110",
+      "desc": "LEGISLATOR"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "EXECUTIVE"
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "1999",
+      "source": "2",
+      "classification": "C",
+      "low": "1000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "oa": "141234.00",
+      "ma": "30245.00",
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "sa": "45123.00",
+      "ra": "30245.00"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "S9812381D": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "TAN XIAO HUI"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "TRICIA TAN XIAO HUI"
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1970-05-17"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "regadd": {
+      "country": "",
+      "unit": "128",
+      "street": "BEDOK NORTH AVENUE 4",
+      "lastupdated": "2018-03-20",
+      "block": "102",
+      "source": "1",
+      "postal": "460102",
+      "classification": "C",
+      "floor": "09",
+      "building": "PEARL GARDEN"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "113"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "TC",
+        "race": "CN",
+        "tob": "0933",
+        "sex": "F",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1108765Z",
+        "hanyupinyinname": "Cheng Yi Ting",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2011-04-13",
+        "name": "Tan Yee Teng",
+        "lastupdated": "2011-04-13",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "3"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1978"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": "SIGLAP SECONDARY SCHOOL"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": "HEALTHCARE ASSISTANT"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "ALPHA"
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "4999",
+      "source": "2",
+      "classification": "C",
+      "low": "4000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "1456789.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2016-12-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2016-11"
+        },
+        {
+          "date": "2016-12-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2016-12"
+        },
+        {
+          "date": "2016-12-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2016-12"
+        },
+        {
+          "date": "2017-01-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2016-12"
+        },
+        {
+          "date": "2017-01-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-01"
+        },
+        {
+          "date": "2017-01-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-01"
+        },
+        {
+          "date": "2017-02-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-01"
+        },
+        {
+          "date": "2017-02-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-02"
+        },
+        {
+          "date": "2017-02-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-02"
+        },
+        {
+          "date": "2017-03-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-02"
+        },
+        {
+          "date": "2017-03-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-03"
+        },
+        {
+          "date": "2017-03-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-03"
+        },
+        {
+          "date": "2017-04-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-03"
+        },
+        {
+          "date": "2017-04-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-04"
+        },
+        {
+          "date": "2017-04-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-04"
+        },
+        {
+          "date": "2017-05-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-04"
+        },
+        {
+          "date": "2017-05-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-05"
+        },
+        {
+          "date": "2017-05-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-05"
+        },
+        {
+          "date": "2017-06-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-05"
+        },
+        {
+          "date": "2017-06-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-06"
+        },
+        {
+          "date": "2017-06-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-06"
+        },
+        {
+          "date": "2017-07-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-06"
+        },
+        {
+          "date": "2017-07-12",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-07"
+        },
+        {
+          "date": "2017-07-21",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-07"
+        },
+        {
+          "date": "2017-08-01",
+          "employer": "Crystal Horse Invest Pte Ltd",
+          "amount": "500.00",
+          "month": "2017-07"
+        },
+        {
+          "date": "2017-08-12",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-08"
+        },
+        {
+          "date": "2017-08-21",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-08"
+        },
+        {
+          "date": "2017-09-01",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-08"
+        },
+        {
+          "date": "2017-09-12",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-09"
+        },
+        {
+          "date": "2017-09-21",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-09"
+        },
+        {
+          "date": "2017-10-01",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-09"
+        },
+        {
+          "date": "2017-10-12",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-10"
+        },
+        {
+          "date": "2017-10-21",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-10"
+        },
+        {
+          "date": "2017-11-01",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-10"
+        },
+        {
+          "date": "2017-11-12",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-11"
+        },
+        {
+          "date": "2017-11-21",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-11"
+        },
+        {
+          "date": "2017-12-01",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-11"
+        },
+        {
+          "date": "2017-12-12",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-12"
+        },
+        {
+          "date": "2017-12-21",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-12"
+        },
+        {
+          "date": "2018-01-01",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2017-12"
+        },
+        {
+          "date": "2018-01-12",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2018-01"
+        },
+        {
+          "date": "2018-01-21",
+          "employer": "Delta Marine Consultants PL",
+          "amount": "750.00",
+          "month": "2018-01"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "1581.48",
+      "source": "1",
+      "ma": "11470.70",
+      "classification": "C",
+      "sa": "21967.09"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },  
+  "S9812382B": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "FREYA LIM GUO EN"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MRS FREYA LIM GUO EN"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "US"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1960-04-19"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "US"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "P"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E12345677F"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "367",
+      "street": "JURONG EAST STREET 21",
+      "lastupdated": "2018-03-20",
+      "block": "288A",
+      "source": "1",
+      "postal": "601288",
+      "classification": "C",
+      "floor": "08",
+      "building": "HDB-JURONG EAST"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "115"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "2"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "443172"
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2017-01-03"
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "TC",
+        "race": "CN",
+        "tob": "1045",
+        "sex": "M",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T1512909G",
+        "hanyupinyinname": "Lin Jun Hao",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2015-07-19",
+        "name": "Lim Jun Hao",
+        "lastupdated": "2015-07-29",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "8"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1987"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS0713J",
+      "desc": "INNOVA JUNIOR COLLEGE"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "3999",
+      "source": "2",
+      "classification": "C",
+      "low": "3000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2456789.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2014-11-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "529.00",
+          "month": "2014-10"
+        },
+        {
+          "date": "2015-01-18",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "951.00",
+          "month": "2014-12"
+        },
+        {
+          "date": "2014-10-19",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "526.00",
+          "month": "2014-10"
+        },
+        {
+          "date": "2014-12-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "541.00",
+          "month": "2014-12"
+        },
+        {
+          "date": "2015-03-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "590.00",
+          "month": "2015-02"
+        },
+        {
+          "date": "2015-02-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "1102.00",
+          "month": "2015-02"
+        },
+        {
+          "date": "2015-04-19",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "607.00",
+          "month": "2015-04"
+        },
+        {
+          "date": "2015-05-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "555.00",
+          "month": "2015-05"
+        },
+        {
+          "date": "2015-06-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "613.00",
+          "month": "2015-06"
+        },
+        {
+          "date": "2015-07-19",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "552.00",
+          "month": "2015-07"
+        },
+        {
+          "date": "2015-08-17",
+          "employer": "EMPLOYER DESCRIPTION : 0696080",
+          "amount": "1422.00",
+          "month": "2015-08"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "27857.35",
+      "source": "1",
+      "ma": "30635.84",
+      "classification": "C",
+      "sa": "90253.27"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "SFM8P"
+    }
+  },
+  "S9812385G": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "DEWANARA VANASAMIN"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CLARISSA DEWANARA VANASAMIN"
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "DU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1950-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E23452346L"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "10",
+      "street": "SIMEI STREET 1",
+      "lastupdated": "2018-03-20",
+      "block": "138",
+      "postal": "520138",
+      "source": "1",
+      "classification": "C",
+      "floor": "38",
+      "building": "HDB-TAMPINES"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "postal": "",
+      "source": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "postal": "",
+      "source": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "115"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "7999",
+      "source": "2",
+      "classification": "C",
+      "low": "7000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "3456789.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2017"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2015-08-16",
+          "employer": "EMPLOYER DESCRIPTION : 3662454",
+          "amount": "563.00",
+          "month": "2015-07"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "2222.22",
+      "source": "1",
+      "ma": "2222.22",
+      "classification": "C",
+      "sa": "2222.22"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "EA123L"
+    }
+  },
+  "S9812387C": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "HOWARD CHEN YU SHENG"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MR HOWARD CHEN YU SHENG"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1998-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E12345677F"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "SG",
+      "unit": "58",
+      "street": "PUNGGOL FIELD",
+      "lastupdated": "2016-01-06",
+      "block": "101B",
+      "source": "1",
+      "postal": "822101",
+      "classification": "C",
+      "floor": "05",
+      "building": "HDB-PUNGGOL"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "11111",
+      "street": "BUKIT BATOK STREET 11",
+      "lastupdated": "",
+      "block": "142",
+      "source": "",
+      "postal": "650142",
+      "classification": "",
+      "floor": "11",
+      "building": "HDB-BUKIT BATOK"
+    },
+    "billadd": {
+      "country": "",
+      "unit": "11111",
+      "street": "BUKIT BATOK STREET 11",
+      "lastupdated": "",
+      "block": "142",
+      "source": "",
+      "postal": "650142",
+      "classification": "",
+      "floor": "11",
+      "building": "HDB-BUKIT BATOK"
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "2016-01-06",
+      "source": "1",
+      "classification": "C",
+      "value": "114"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "3"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1976"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3006F",
+      "desc": "GAN ENG SENG SCHOOL"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "24133",
+      "desc": "FUND MANAGER"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "NEED ALL COMPANY"
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "3999",
+      "source": "2",
+      "classification": "C",
+      "low": "3000"
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "",
+      "source": "1",
+      "ma": "",
+      "classification": "C",
+      "sa": ""
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "S9912363Z": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "CHENG QI FA"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CHEN QI FA"
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "ESTHER CHEN QI FA"
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "U"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "KE"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1999-10-06"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "P"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E3546387W"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "22",
+      "street": "LORONG 1 TOA PAYOH",
+      "lastupdated": "",
+      "block": "123",
+      "source": "1",
+      "postal": "310123",
+      "classification": "C",
+      "floor": "12",
+      "building": "TOA PAYOH VIEW"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "113"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "84567.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2016"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2614-12-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2014-12"
+        },
+        {
+          "date": "2615-01-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-01"
+        },
+        {
+          "date": "2615-02-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-02"
+        },
+        {
+          "date": "2615-03-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-03"
+        },
+        {
+          "date": "2615-04-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-04"
+        },
+        {
+          "date": "2615-05-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-05"
+        },
+        {
+          "date": "2615-06-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-06"
+        },
+        {
+          "date": "2615-07-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-07"
+        },
+        {
+          "date": "2615-08-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-08"
+        },
+        {
+          "date": "2615-09-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-09"
+        },
+        {
+          "date": "2615-10-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-10"
+        },
+        {
+          "date": "2615-11-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-11"
+        },
+        {
+          "date": "2615-12-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2015-12"
+        },
+        {
+          "date": "2616-01-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "1582.20",
+          "month": "2016-01"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "141234.00",
+      "source": "1",
+      "ma": "30213.00",
+      "classification": "C",
+      "sa": "45123.00"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "SBA6543K"
+    }
+  },
+  "S9912372I": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "TOMMY S/O BALA"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "TOMMY"
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MR TOMMY"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "IN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "CD"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1999-10-07"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "IN"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "P"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "22",
+      "street": "LORONG 1 TOA PAYOH",
+      "lastupdated": "",
+      "block": "123",
+      "source": "1",
+      "postal": "310123",
+      "classification": "C",
+      "floor": "12",
+      "building": "TOA PAYOH VIEW"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "113"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "5"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2011-02-15"
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "",
+        "race": "",
+        "tob": "",
+        "sex": "",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8512345Y",
+        "hanyupinyinname": "",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "",
+        "name": "",
+        "lastupdated": "1985-08-15",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "",
+        "race": "",
+        "tob": "",
+        "sex": "",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8702311K",
+        "hanyupinyinname": "",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "",
+        "name": "",
+        "lastupdated": "1999-01-11",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "4"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "2001"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "",
+      "desc": "UNIVERSITY"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "11121",
+      "desc": "SENIOR GOVERNMENT OFFICIAL"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "75000.00"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2016"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [
+        {
+          "date": "2614-12-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2014-12"
+        },
+        {
+          "date": "2615-01-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-01"
+        },
+        {
+          "date": "2615-02-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-02"
+        },
+        {
+          "date": "2615-03-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-03"
+        },
+        {
+          "date": "2615-04-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-04"
+        },
+        {
+          "date": "2615-05-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-05"
+        },
+        {
+          "date": "2615-06-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-06"
+        },
+        {
+          "date": "2615-07-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-07"
+        },
+        {
+          "date": "2615-08-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-08"
+        },
+        {
+          "date": "2615-09-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-09"
+        },
+        {
+          "date": "2615-10-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-10"
+        },
+        {
+          "date": "2615-11-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-11"
+        },
+        {
+          "date": "2615-12-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2015-12"
+        },
+        {
+          "date": "2616-01-28",
+          "employer": "CLEAR LINK PTE LTD",
+          "amount": "2866.99",
+          "month": "2016-01"
+        }
+      ],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "0.00",
+      "source": "1",
+      "ma": "0.00",
+      "classification": "C",
+      "sa": "0.00"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "S6005053H": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MY,INFO%BB"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "HANYUD12"
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MYINFOALIAS D"
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1948-09-10"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E2345234FDFEW9874326LO"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2025-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "112",
+      "street": "BUKIT BATOK STREET 25",
+      "lastupdated": "",
+      "block": "289C",
+      "source": "1",
+      "postal": "652289",
+      "classification": "C",
+      "floor": "02",
+      "building": "NATURE VIEW"
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "115"
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "5"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "2011-02-15"
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "N"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "oa": "12345.00",
+      "ma": "76987.00",
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "sa": "73627.00",
+      "ra": "32864.00"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": "SFH2K"
+    }
+  },
+  "S6005055D": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MY.INFO:CC"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "HANYUEE"
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MYINFOALIAS E"
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "NAMEG"
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SK"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "IN"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1948-02-01"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "C"
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E12345677F"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "1999-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "",
+      "street": "KG SG RAMAL LUAR",
+      "lastupdated": "",
+      "block": "75",
+      "source": "1",
+      "postal": "43000",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "53201",
+      "desc": ""
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "NA"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "oa": "39827.32",
+      "ma": "54353.23",
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "sa": "54353.88",
+      "ra": "34265.64"
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "G1612348Q": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "ALFONSO CRUZ"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "EU"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "AU"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1992-02-01"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "AU"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E12348742J"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2023-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "1",
+      "postal": "",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "N"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "1"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "13304",
+      "desc": "IT SERVICE MANAGER"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "UBI COMPUTER SYSTEMS PTE. LTD."
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "Live"
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "2019-12-31"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "123437.12"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "",
+      "source": "1",
+      "ma": "",
+      "classification": "C",
+      "sa": ""
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },
+  "G1612349N": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "ALFRED CHONG BOON HAO"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "M"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1948-12-11"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": "E43278273K"
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "2024-01-01"
+    },
+    "regadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "1",
+      "postal": "",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "342",
+      "street": "HOUGANG AVENUE 1",
+      "lastupdated": "2018-03-21",
+      "block": "238",
+      "source": "2",
+      "postal": "530238",
+      "classification": "C",
+      "floor": "04",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "2"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "AL6980131721"
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "ID"
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "1992-03-21"
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "",
+        "race": "",
+        "tob": "",
+        "sex": "",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8501177J",
+        "hanyupinyinname": "",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "",
+        "name": "",
+        "lastupdated": "2005-07-12",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "TC",
+        "race": "CN",
+        "tob": "1208",
+        "sex": "M",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "T0512909G",
+        "hanyupinyinname": "Zhang Jun Hao",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "2005-07-12",
+        "name": "Chong Jun Hao",
+        "lastupdated": "2005-07-12",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "7"
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "1987"
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "NTU",
+      "desc": "NANYANG TECHNOLOGICAL UNIVERSITY"
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "13292",
+      "desc": "SENIOR MANAGER, QUALITY ASSURANCE"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "JAPAN <CIRCUIT> INDUS / TRIAL CO., LTD."
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "Live"
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "2019-12-31"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "",
+      "source": "1",
+      "ma": "",
+      "classification": "C",
+      "sa": ""
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  },  
+  "G1612350T": {
+    "name": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "JENNY LIM WAI FOOK"
+    },
+    "hanyupinyinname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "aliasname": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hanyupinyinaliasname": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "marriedname": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "sex": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "F"
+    },
+    "race": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "CN"
+    },
+    "secondaryrace": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "dialect": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "nationality": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "dob": {
+      "lastupdated": "2018-03-20",
+      "source": "1",
+      "classification": "C",
+      "value": "1992-02-01"
+    },
+    "birthcountry": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": "MY"
+    },
+    "residentialstatus": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportnumber": {
+      "lastupdated": "2018-08-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "passportexpirydate": {
+      "lastupdated": "2018-03-23",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "regadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "1",
+      "postal": "",
+      "classification": "C",
+      "floor": "",
+      "building": ""
+    },
+    "mailadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "billadd": {
+      "country": "",
+      "unit": "",
+      "street": "",
+      "lastupdated": "",
+      "block": "",
+      "source": "",
+      "postal": "",
+      "classification": "",
+      "floor": "",
+      "building": ""
+    },
+    "housingtype": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "hdbtype": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "ownerprivate": {
+      "lastupdated": "2017-04-26",
+      "source": "1",
+      "classification": "C",
+      "value": "Y"
+    },
+    "email": {
+      "lastupdated": "2018-08-23",
+      "source": "4",
+      "classification": "C",
+      "value": "myinfotesting@gmail.com"
+    },
+    "homeno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "2",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "69876543"
+    },
+    "mobileno": {
+      "lastupdated": "2018-08-23",
+      "code": "65",
+      "source": "4",
+      "classification": "C",
+      "prefix": "+",
+      "nbr": "97399245"
+    },
+    "marital": {
+      "lastupdated": "2018-03-21",
+      "source": "1",
+      "classification": "C",
+      "value": "2"
+    },
+    "marriagecertno": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "560123"
+    },
+    "countryofmarriage": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "SG"
+    },
+    "marriagedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": "1992-03-21"
+    },
+    "divorcedate": {
+      "lastupdated": "",
+      "source": "1",
+      "classification": "C",
+      "value": ""
+    },
+    "childrenbirthrecords": [
+      {
+        "dialect": "",
+        "race": "",
+        "tob": "",
+        "sex": "",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8501177J",
+        "hanyupinyinname": "",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "",
+        "name": "",
+        "lastupdated": "2005-07-12",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "",
+        "race": "",
+        "tob": "",
+        "sex": "",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8310088L",
+        "hanyupinyinname": "",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "",
+        "name": "",
+        "lastupdated": "1983-03-21",
+        "secondaryrace": ""
+      },
+      {
+        "dialect": "",
+        "race": "",
+        "tob": "",
+        "sex": "",
+        "source": "1",
+        "classification": "C",
+        "birthcertno": "S8119988A",
+        "hanyupinyinname": "",
+        "hanyupinyinaliasname": "",
+        "marriedname": "",
+        "aliasname": "",
+        "dob": "",
+        "name": "",
+        "lastupdated": "1981-02-10",
+        "secondaryrace": ""
+      }
+    ],
+    "edulevel": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "gradyear": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    },
+    "schoolname": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "T07GS3011J",
+      "desc": ""
+    },
+    "occupation": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "",
+      "desc": "CLERICAL ASSISTANT"
+    },
+    "employment": {
+      "lastupdated": "2017-10-11",
+      "source": "2",
+      "classification": "C",
+      "value": "CST CONTAINER SERVICES PTE LTD"
+    },
+    "workpassstatus": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "Live"
+    },
+    "workpassexpirydate": {
+      "lastupdated": "2018-03-02",
+      "source": "1",
+      "classification": "C",
+      "value": "2019-12-31"
+    },
+    "householdincome": {
+      "lastupdated": "2017-10-24",
+      "high": "",
+      "source": "2",
+      "classification": "C",
+      "low": ""
+    },
+    "assessableincome": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "170402.02"
+    },
+    "assessyear": {
+      "lastupdated": "2017-03-16",
+      "source": "1",
+      "classification": "C",
+      "value": "2018"
+    },
+    "cpfcontributions": {
+      "lastupdated": "2017-03-16",
+      "cpfcontribution": [],
+      "source": "1",
+      "classification": "C"
+    },
+    "cpfbalances": {
+      "lastupdated": "2018-08-23",
+      "oa": "",
+      "source": "1",
+      "ma": "",
+      "classification": "C",
+      "sa": ""
+    },
+    "vehno": {
+      "lastupdated": "",
+      "source": "2",
+      "classification": "C",
+      "value": ""
+    }
+  }
+}


### PR DESCRIPTION
Given the generally long process of onboarding onto MyInfo and its regular maintenance schedules, it is generally helpful to have a mock service that can stand in for the real thing. MockInfo is built on top of MockPass and is backed by a static file generated from the list of known test personas provided by the MyInfo team.

MockInfo includes functionality that mimics the person and person-basic endpoints and the typical consent flow for a user. It features both TUO authorization available to government systems and token-based authorization required for most other applications.

See commits for further details