### PR TITLE
Make signing/encryption optional and fix some template issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ $ export MOCKPASS_UEN=123456789A
 
 $ export SHOW_LOGIN_PAGE=true # Optional
 
+# Disable signing/encryption (Optional, by default `true`)
+$ export SIGN_ASSERTION=false
+$ export ENCRYPT_ASSERTION=false
+$ export SIGN_RESPONSE=false
+$ export RESOLVE_ARTIFACT_REQUEST_SIGNED=false
+
 $ npx mockpass
 MockPass listening on 5156
 ```

--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ const app = configSpcp(express(), {
   serviceProvider,
   idpConfig: {
     singPass: {
-      id: process.env.SINGPASS_IDP_ID || 'https://saml-internet.singpass.gov.sg/FIM/sps/SingpassIDPFed/saml20',
+      id: process.env.SINGPASS_IDP_ID || 'http://localhost:5156/singpass/saml20',
       assertEndpoint: process.env.SINGPASS_ASSERT_ENDPOINT,
     },
     corpPass: {
-      id: process.env.CORPPASS_IDP_ID || 'https://saml.corppass.gov.sg/FIM/sps/CorpIDPFed/saml20',
+      id: process.env.CORPPASS_IDP_ID || 'http://localhost:5156/singpass/saml20',
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },

--- a/index.js
+++ b/index.js
@@ -15,6 +15,13 @@ const serviceProvider = {
   pubKey: fs.readFileSync(path.resolve(__dirname, process.env.SERVICE_PROVIDER_PUB_KEY || './static/certs/key.pub')),
 }
 
+const cryptoConfig = {
+  signAssertion: process.env.SIGN_ASSERTION !== 'false', //default to true to be backward compatable
+  signResponse: process.env.SIGN_RESPONSE !== 'false',
+  encryptAssertion: process.env.ENCRYPT_ASSERTION !== 'false',
+  resolveArtifactRequestSigned: process.env.RESOLVE_ARTIFACT_REQUEST_SIGNED !== 'false',
+}
+
 const app = configSpcp(express(), {
   serviceProvider,
   idpConfig: {
@@ -28,6 +35,7 @@ const app = configSpcp(express(), {
     },
   },
   showLoginPage: process.env.SHOW_LOGIN_PAGE === 'true',
+  cryptoConfig,
 })
 
 configMyInfo(app, { serviceProvider, port: PORT })

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const app = configSpcp(express(), {
       assertEndpoint: process.env.SINGPASS_ASSERT_ENDPOINT,
     },
     corpPass: {
-      id: process.env.CORPPASS_IDP_ID || 'http://localhost:5156/singpass/saml20',
+      id: process.env.CORPPASS_IDP_ID || 'http://localhost:5156/corppass/saml20',
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -2,6 +2,7 @@ const base64 = require('base-64')
 const fs = require('fs')
 const { render } = require('mustache')
 const path = require('path')
+const moment = require('moment')
 
 const readFrom = p => fs.readFileSync(path.resolve(__dirname, p), 'utf8')
 
@@ -57,12 +58,18 @@ const identities = {
 const makeCorpPass = ({ NRIC, UEN }) => render(
   TEMPLATE,
   {
+    issueInstant: moment.utc().format(),
     name: UEN,
     value: base64.encode(render(corpPassTemplate, { NRIC, UEN })),
   }
 )
 
-const makeSingPass = NRIC => render(TEMPLATE, { name: 'UserName', value: NRIC })
+const makeSingPass = (NRIC) => render(TEMPLATE,
+  {
+    name: 'UserName',
+    value: NRIC,
+    issueInstant: moment.utc().format(),
+  })
 
 const NRIC = process.env.MOCKPASS_NRIC || identities.singPass[0]
 const CORPPASS_NRIC = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -18,7 +18,7 @@ const LOGIN_TEMPLATE = fs.readFileSync(path.resolve(__dirname, '../../static/htm
 
 const MYINFO_ASSERT_ENDPOINT = '/consent/myinfo-com'
 
-function config (app, { showLoginPage, serviceProvider, idpConfig }) {
+function config(app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig }) {
   const { verifySignature, sign, promiseToEncryptAssertion } = crypto(serviceProvider)
   app.use(morgan('combined'))
 
@@ -57,7 +57,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
         const { body } = req
         const xml = dom(body)
 
-        if (!verifySignature(xml)) {
+        if (cryptoConfig.resolveArtifactRequestSigned && !verifySignature(xml)) {
           res.status(400).send('Request has bad signature')
         } else {
           // Grab the SAML artifact
@@ -69,19 +69,32 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
           // Sign and encrypt the assertion
           const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
           const index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
-          const assertion = assertions.identities[idp][index]
-            ? assertions[idp].create(assertions.identities[idp][index])
-            : assertions[idp].default
-          const signedAssertion = sign(assertion, "//*[local-name(.)='Assertion']")
-          promiseToEncryptAssertion(signedAssertion)
-            .then(assertion => {
-              const response = render(TEMPLATE, { assertion })
-              const signedResponse = sign(
-                sign(response, "//*[local-name(.)='Response']"),
-                "//*[local-name(.)='ArtifactResponse']"
-              )
-              res.send(signedResponse)
-            })
+
+          const assertionPromise = function () {
+            let result = assertions.identities[idp][index]
+              ? assertions[idp].create(assertions.identities[idp][index])
+              : assertions[idp].default
+
+            if (cryptoConfig.signAssertion) {
+              result = sign(result, "//*[local-name(.)='Assertion']");
+            }
+
+            if (cryptoConfig.encryptAssertion) {
+              result = promiseToEncryptAssertion(result)
+            }
+            return Promise.resolve(result)
+          }();
+
+          assertionPromise.then(
+            assertion => {
+              let response = render(TEMPLATE, { assertion })
+              if (cryptoConfig.signResponse) {
+                response = sign(response, "//*[local-name(.)='Response']"),
+                  "//*[local-name(.)='ArtifactResponse']"
+              }
+              res.send(response)
+            }
+          );
         }
       }
     )

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -5,6 +5,7 @@ const { render } = require('mustache')
 const path = require('path')
 const { DOMParser } = require('xmldom')
 const xpath = require('xpath')
+const moment = require('moment')
 
 const assertions = require('../assertions')
 const crypto = require('../crypto')
@@ -87,7 +88,7 @@ function config(app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig }
 
           assertionPromise.then(
             assertion => {
-              let response = render(TEMPLATE, { assertion })
+              let response = render(TEMPLATE, { assertion, issueInstant: moment.utc().format() })
               if (cryptoConfig.signResponse) {
                 response = sign(response, "//*[local-name(.)='Response']"),
                   "//*[local-name(.)='ArtifactResponse']"

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -32,7 +32,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
         const identities = assertions.identities[idp]
         const values = identities
           .map((id, index) => {
-            const samlArt = samlArtifact(idpConfig[idp].id, index)
+            const samlArt = encodeURIComponent(samlArtifact(idpConfig[idp].id, index))
             const assertURL = `${assertEndpoint}?SAMLart=${samlArt}&RelayState=${relayState}`
             if (assertions.myinfo.personas[id]) {
               id += ' [MyInfo]'
@@ -42,7 +42,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig }) {
         const response = render(LOGIN_TEMPLATE, values)
         res.send(response)
       } else {
-        const samlArt = samlArtifact(idpConfig[idp].id)
+        const samlArt = encodeURIComponent(samlArtifact(idpConfig[idp].id))
         const assertURL = `${assertEndpoint}?SAMLart=${samlArt}&RelayState=${relayState}`
         console.warn(`Redirecting login from ${req.query.PartnerId} to ${assertURL}`)
         res.redirect(assertURL)

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -19,7 +19,7 @@ const LOGIN_TEMPLATE = fs.readFileSync(path.resolve(__dirname, '../../static/htm
 
 const MYINFO_ASSERT_ENDPOINT = '/consent/myinfo-com'
 
-function config(app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig }) {
+function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig }) {
   const { verifySignature, sign, promiseToEncryptAssertion } = crypto(serviceProvider)
   app.use(morgan('combined'))
 
@@ -71,20 +71,17 @@ function config(app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig }
           const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
           const index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
 
-          const assertionPromise = function () {
-            let result = assertions.identities[idp][index]
-              ? assertions[idp].create(assertions.identities[idp][index])
-              : assertions[idp].default
 
-            if (cryptoConfig.signAssertion) {
-              result = sign(result, "//*[local-name(.)='Assertion']");
-            }
+          let result = assertions.identities[idp][index]
+            ? assertions[idp].create(assertions.identities[idp][index])
+            : assertions[idp].default
 
-            if (cryptoConfig.encryptAssertion) {
-              result = promiseToEncryptAssertion(result)
-            }
-            return Promise.resolve(result)
-          }();
+          if (cryptoConfig.signAssertion) {
+            result = sign(result, "//*[local-name(.)='Assertion']")
+          }
+          const assertionPromise = cryptoConfig.encryptAssertion
+            ? promiseToEncryptAssertion(result)
+            : Promise.resolve(result)
 
           assertionPromise.then(
             assertion => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,6 +1242,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.16.3",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.11",
+    "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "mustache": "^2.3.2",
     "uuid": "^3.3.2",

--- a/static/saml/unsigned-assertion.xml
+++ b/static/saml/unsigned-assertion.xml
@@ -1,4 +1,4 @@
-<saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+<saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="{{issueInstant}}">
   <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
   <saml:Subject>
     <saml:NameID Format="urn:ibm:names:ITFIM:5.1:accessmanager">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>

--- a/static/saml/unsigned-assertion.xml
+++ b/static/saml/unsigned-assertion.xml
@@ -1,4 +1,4 @@
-<saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+<saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
   <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
   <saml:Subject>
     <saml:NameID Format="urn:ibm:names:ITFIM:5.1:accessmanager">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>

--- a/static/saml/unsigned-response.xml
+++ b/static/saml/unsigned-response.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
-  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
-  <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs">
-    <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
-    <samlp:Status>
-      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
-    </samlp:Status>
-    {{{ assertion }}}
-  </samlp:Response>
-</samlp:ArtifactResponse>
+<soap11:Envelope xmlns:soap11="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap11:Body>
+    <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" 
+      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+      <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+      <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs">
+        <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+        <samlp:Status>
+          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        </samlp:Status>
+                {{{ assertion }}}
+      </samlp:Response>
+    </samlp:ArtifactResponse>
+  </soap11:Body>
+</soap11:Envelope>

--- a/static/saml/unsigned-response.xml
+++ b/static/saml/unsigned-response.xml
@@ -2,9 +2,9 @@
 <soap11:Envelope xmlns:soap11="http://schemas.xmlsoap.org/soap/envelope/">
   <soap11:Body>
     <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" 
-      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
       <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
-      <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs">
+      <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="http://sp.example.com/demo1/index.php?acs">
         <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
         <samlp:Status>
           <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>


### PR DESCRIPTION
- Made  singing/encryption optional
- Fixed some bugs of  the response templates
- Url encoded the artifactId
- Set `issueInstant` to utc time now.