### PR TITLE
Allow configurable assertion recipient field. Simplify assertion template creation

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -67,10 +67,10 @@ const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }) => render(
   }
 )
 
-const defaultNric = process.env.MOCKPASS_NRIC || identities.singPass[0]
+const nric = process.env.MOCKPASS_NRIC || identities.singPass[0]
 const recipient = process.env.SERVICE_PROVIDER_RECIPIENT || "http://localhost:8080/saml/SSO"
 
-const makeSingPass = (NRIC = defaultNric, RECIPIENT = recipient) => render(
+const makeSingPass = (NRIC = nric, RECIPIENT = recipient) => render(
   TEMPLATE,
   {
     name: 'UserName',

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -68,13 +68,15 @@ const makeCorpPass = ({ NRIC = corpPassNric, UEN = makeCorpPass}) => render(
 )
 
 const defaultNric = process.env.MOCKPASS_NRIC || identities.singPass[0]
+const recipient = process.env.SERVICE_PROVIDER_RECIPIENT || "http://localhost:8080/saml/SSO"
 
-const makeSingPass = (NRIC = defaultNric) => render(
+const makeSingPass = (NRIC = defaultNric, RECIPIENT = recipient) => render(
   TEMPLATE,
   {
     name: 'UserName',
     value: NRIC,
     issueInstant: moment.utc().format(),
+    recipient: RECIPIENT,
   })
 
 module.exports = {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -58,7 +58,7 @@ const identities = {
 const corpPassNric = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
 const uen = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
 
-const makeCorpPass = ({ NRIC = corpPassNric, UEN = makeCorpPass}) => render(
+const makeCorpPass = ({ NRIC = corpPassNric, UEN = uen}) => render(
   TEMPLATE,
   {
     issueInstant: moment.utc().format(),

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -58,12 +58,12 @@ const identities = {
 const corpPassNric = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
 const uen = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
 
-const makeCorpPass = ({ NRIC = corpPassNric, UEN = uen}) => render(
+const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }) => render(
   TEMPLATE,
   {
     issueInstant: moment.utc().format(),
-    name: UEN,
-    value: base64.encode(render(corpPassTemplate, { NRIC, UEN })),
+    name: source.UEN,
+    value: base64.encode(render(corpPassTemplate, source)),
   }
 )
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -55,7 +55,10 @@ const identities = {
   ],
 }
 
-const makeCorpPass = ({ NRIC, UEN }) => render(
+const corpPassNric = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
+const uen = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
+
+const makeCorpPass = ({ NRIC = corpPassNric, UEN = makeCorpPass}) => render(
   TEMPLATE,
   {
     issueInstant: moment.utc().format(),
@@ -64,24 +67,21 @@ const makeCorpPass = ({ NRIC, UEN }) => render(
   }
 )
 
-const makeSingPass = (NRIC) => render(TEMPLATE,
+const defaultNric = process.env.MOCKPASS_NRIC || identities.singPass[0]
+
+const makeSingPass = (NRIC = defaultNric) => render(
+  TEMPLATE,
   {
     name: 'UserName',
     value: NRIC,
     issueInstant: moment.utc().format(),
   })
 
-const NRIC = process.env.MOCKPASS_NRIC || identities.singPass[0]
-const CORPPASS_NRIC = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
-const UEN = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
-
 module.exports = {
   singPass: {
-    default: makeSingPass(NRIC),
     create: makeSingPass,
   },
   corpPass: {
-    default: makeCorpPass({ NRIC: CORPPASS_NRIC, UEN }),
     create: makeCorpPass,
   },
   identities,

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -57,18 +57,19 @@ const identities = {
 
 const corpPassNric = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
 const uen = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
+const recipient = process.env.SERVICE_PROVIDER_RECIPIENT || "http://sp.example.com/demo1/index.php?acs"
 
-const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }) => render(
+const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }, RECIPIENT = recipient) => render(
   TEMPLATE,
   {
     issueInstant: moment.utc().format(),
     name: source.UEN,
     value: base64.encode(render(corpPassTemplate, source)),
+    recipient: RECIPIENT,
   }
 )
 
 const nric = process.env.MOCKPASS_NRIC || identities.singPass[0]
-const recipient = process.env.SERVICE_PROVIDER_RECIPIENT || "http://localhost:8080/saml/SSO"
 
 const makeSingPass = (NRIC = nric, RECIPIENT = recipient) => render(
   TEMPLATE,

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -73,7 +73,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
 
           let result = assertions.identities[idp][index]
             ? assertions[idp].create(assertions.identities[idp][index])
-            : assertions[idp].default
+            : assertions[idp].create()
 
           if (cryptoConfig.signAssertion) {
             result = sign(result, "//*[local-name(.)='Assertion']")

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -71,9 +71,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
           const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
           const index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
 
-          let result = assertions.identities[idp][index]
-            ? assertions[idp].create(assertions.identities[idp][index])
-            : assertions[idp].create()
+          let result = assertions[idp].create(assertions.identities[idp][index])
 
           if (cryptoConfig.signAssertion) {
             result = sign(result, "//*[local-name(.)='Assertion']")

--- a/static/saml/unsigned-assertion.xml
+++ b/static/saml/unsigned-assertion.xml
@@ -1,9 +1,9 @@
 <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="{{issueInstant}}">
   <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
   <saml:Subject>
-    <saml:NameID Format="urn:ibm:names:ITFIM:5.1:accessmanager">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+    <saml:NameID Format="urn:ibm:names:ITFIM:5.1:accessmanager">{{value}}</saml:NameID>
     <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-      <saml:SubjectConfirmationData NotOnOrAfter="2224-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      <saml:SubjectConfirmationData NotOnOrAfter="2224-01-18T06:21:48Z" Recipient="{{recipient}}" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
     </saml:SubjectConfirmation>
   </saml:Subject>
   <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2224-01-18T06:21:48Z">
@@ -11,7 +11,7 @@
       <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
     </saml:AudienceRestriction>
   </saml:Conditions>
-  <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2224-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
+  <saml:AuthnStatement AuthnInstant="{{issueInstant}}" SessionNotOnOrAfter="2224-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
     <saml:AuthnContext>
       <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
     </saml:AuthnContext>


### PR DESCRIPTION
For deployment in multiple environments, there's a need to allow the recipient value in the Assertion to be configurable.

Simplify the assertion template creation to always create the template for every POST call to spcp. This would ensure that the 'issueInstant' field is always set with the latest date and time. 