### PR TITLE
Use variables to populate templates in order to pass SAML validation

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -57,27 +57,33 @@ const identities = {
 
 const corpPassNric = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
 const uen = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
-const recipient = process.env.SERVICE_PROVIDER_RECIPIENT || "http://sp.example.com/demo1/index.php?acs"
+const audience = process.env.SERVICE_PROVIDER_ENTITY_ID || "http://sp.example.com/demo1/metadata.php"
 
-const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }, RECIPIENT = recipient) => render(
+const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }, ISSUER = issuer, RECIPIENT = recipient, INRESPONSETO = inResponseTo, AUDIENCE = audience) => render(
   TEMPLATE,
   {
     issueInstant: moment.utc().format(),
     name: source.UEN,
     value: base64.encode(render(corpPassTemplate, source)),
     recipient: RECIPIENT,
+    issuer: ISSUER,
+    inResponseTo: INRESPONSETO,
+    audience: AUDIENCE
   }
 )
 
 const nric = process.env.MOCKPASS_NRIC || identities.singPass[0]
 
-const makeSingPass = (NRIC = nric, RECIPIENT = recipient) => render(
+const makeSingPass = (NRIC = nric, ISSUER = issuer, RECIPIENT = recipient, INRESPONSETO = inResponseTo, AUDIENCE = audience) => render(
   TEMPLATE,
   {
     name: 'UserName',
     value: NRIC,
     issueInstant: moment.utc().format(),
     recipient: RECIPIENT,
+    issuer: ISSUER,
+    inResponseTo: INRESPONSETO,
+    audience: AUDIENCE
   })
 
 module.exports = {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -59,7 +59,7 @@ const corpPassNric = process.env.MOCKPASS_NRIC || identities.corpPass[0].NRIC
 const uen = process.env.MOCKPASS_UEN || identities.corpPass[0].UEN
 const audience = process.env.SERVICE_PROVIDER_ENTITY_ID || "http://sp.example.com/demo1/metadata.php"
 
-const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }, ISSUER = issuer, RECIPIENT = recipient, INRESPONSETO = inResponseTo, AUDIENCE = audience) => render(
+const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }, ISSUER = issuer, RECIPIENT = recipient, IN_RESPONSE_TO = inResponseTo, AUDIENCE = audience) => render(
   TEMPLATE,
   {
     issueInstant: moment.utc().format(),
@@ -67,14 +67,14 @@ const makeCorpPass = (source = { NRIC: corpPassNric, UEN: uen }, ISSUER = issuer
     value: base64.encode(render(corpPassTemplate, source)),
     recipient: RECIPIENT,
     issuer: ISSUER,
-    inResponseTo: INRESPONSETO,
+    inResponseTo: IN_RESPONSE_TO,
     audience: AUDIENCE
   }
 )
 
 const nric = process.env.MOCKPASS_NRIC || identities.singPass[0]
 
-const makeSingPass = (NRIC = nric, ISSUER = issuer, RECIPIENT = recipient, INRESPONSETO = inResponseTo, AUDIENCE = audience) => render(
+const makeSingPass = (NRIC = nric, ISSUER = issuer, RECIPIENT = recipient, IN_RESPONSE_TO = inResponseTo, AUDIENCE = audience) => render(
   TEMPLATE,
   {
     name: 'UserName',
@@ -82,7 +82,7 @@ const makeSingPass = (NRIC = nric, ISSUER = issuer, RECIPIENT = recipient, INRES
     issueInstant: moment.utc().format(),
     recipient: RECIPIENT,
     issuer: ISSUER,
-    inResponseTo: INRESPONSETO,
+    inResponseTo: IN_RESPONSE_TO,
     audience: AUDIENCE
   })
 

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -71,7 +71,9 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
           const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
           const index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
 
-          let result = assertions[idp].create(assertions.identities[idp][index])
+          const samlArtifactResolveId = xpath.select("string(//*[local-name(.)='ArtifactResolve']/@ID)", xml)
+
+          let result = assertions[idp].create(assertions.identities[idp][index], idpConfig[idp].id, idpConfig[idp].assertEndpoint, samlArtifactResolveId)
 
           if (cryptoConfig.signAssertion) {
             result = sign(result, "//*[local-name(.)='Assertion']")
@@ -82,7 +84,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
 
           assertionPromise.then(
             assertion => {
-              let response = render(TEMPLATE, { assertion, issueInstant: moment.utc().format() })
+              let response = render(TEMPLATE, { assertion, issueInstant: moment.utc().format(), issuer: idpConfig[idp].id, destination: idpConfig[idp].assertEndpoint, inResponseTo: samlArtifactResolveId })
               if (cryptoConfig.signResponse) {
                 response = sign(
                   sign(response, "//*[local-name(.)='Response']"),

--- a/static/saml/unsigned-assertion.xml
+++ b/static/saml/unsigned-assertion.xml
@@ -1,14 +1,14 @@
 <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="{{issueInstant}}">
-  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+  <saml:Issuer>{{issuer}}</saml:Issuer>
   <saml:Subject>
     <saml:NameID Format="urn:ibm:names:ITFIM:5.1:accessmanager">{{value}}</saml:NameID>
     <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-      <saml:SubjectConfirmationData NotOnOrAfter="2224-01-18T06:21:48Z" Recipient="{{recipient}}" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      <saml:SubjectConfirmationData NotOnOrAfter="2224-01-18T06:21:48Z" Recipient="{{recipient}}" InResponseTo="{{inResponseTo}}"/>
     </saml:SubjectConfirmation>
   </saml:Subject>
   <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2224-01-18T06:21:48Z">
     <saml:AudienceRestriction>
-      <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+      <saml:Audience>{{audience}}</saml:Audience>
     </saml:AudienceRestriction>
   </saml:Conditions>
   <saml:AuthnStatement AuthnInstant="{{issueInstant}}" SessionNotOnOrAfter="2224-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">

--- a/static/saml/unsigned-response.xml
+++ b/static/saml/unsigned-response.xml
@@ -2,10 +2,10 @@
 <soap11:Envelope xmlns:soap11="http://schemas.xmlsoap.org/soap/envelope/">
   <soap11:Body>
     <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" 
-      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
-      <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
-      <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="http://sp.example.com/demo1/index.php?acs">
-        <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="{{destination}}" InResponseTo="{{inResponseTo}}">
+      <saml:Issuer>{{issuer}}</saml:Issuer>
+      <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="{{destination}}">
+        <saml:Issuer>{{issuer}}</saml:Issuer>
         <samlp:Status>
           <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
         </samlp:Status>


### PR DESCRIPTION
Using Spring Security SAML (https://projects.spring.io/spring-security-saml/) for a web application currently fails when using MockPass as Spring Security SAML performs some validation against the ArtifactResponse.

- Removed SERVICE_PROVIDER_RECIPIENT as the recipient in SubjectConfirmationData should tally with the service provider's assertion consumer service url.
- Set the destination in the ArtifactResponse to tally with the service provider's assertion consumer service url.
- Added SERVICE_PROVIDER_ENTITY_ID to populate the Audience in AudienceRestriction.
- Set InResponseTo to the request ArtifactResolve ID.
- Set Issuer to the IDP ID.

This pull request has been validated against a sample webapp using spring-security-saml2-core 1.0.9.RELEASE.