### PR TITLE
Add .gitattributes indicate not to apply eol conversion for public/mo…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set to not apply eol conversion for subresource integrity check
+public/mockpass/resources/js/*.js -text


### PR DESCRIPTION
**Symptom**
After cloning the project in windows, Chrome fails to properly render the login page as it was unable to find a valid digest in the integrity attribute for jquery-3.3.1.js and bootstrap.min.js.

**Cause**
Git on windows by default will convert line endings (core.autocrlf=true). When cloning the repository, git changes the line-endings of the 2 javascript files and hence the sha hashes won't match anymore.

**Solution**
Since getting windows users to change their settings (core.autocrlf=input) may cause other issues, it's preferable to create a .gitattributes file and specify the js files git shouldn't try to touch. 