### PR TITLE
Allow assertion endpoint to be specified using request parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Alternatively, provide the paths to your app cert as env vars
 $ npm install @opengovsg/mockpass
 
 # Some familiarity with SAML Artifact Binding is assumed
-# Configure where MockPass should send SAML artifact to
+# Optional: Configure where MockPass should send SAML artifact to, default endpoint will be `PartnerId` in request query parameter.
 $ export SINGPASS_ASSERT_ENDPOINT=http://localhost:5000/singpass/assert
 $ export CORPPASS_ASSERT_ENDPOINT=http://localhost:5000/corppass/assert
 

--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ const { configSpcp, configMyInfo } = require('./lib/express')
 
 const PORT = process.env.MOCKPASS_PORT || process.env.PORT || 5156
 
-if (!process.env.SINGPASS_ASSERT_ENDPOINT && !process.env.CORPPASS_ASSERT_ENDPOINT) {
-  throw new Error('Either SINGPASS_ASSERT_ENDPOINT or CORPPASS_ASSERT_ENDPOINT must be set')
-}
 const serviceProvider = {
   cert: fs.readFileSync(path.resolve(__dirname, process.env.SERVICE_PROVIDER_CERT_PATH || './static/certs/server.crt')),
   pubKey: fs.readFileSync(path.resolve(__dirname, process.env.SERVICE_PROVIDER_PUB_KEY || './static/certs/key.pub')),
@@ -35,7 +32,7 @@ const app = configSpcp(express(), {
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },
-  showLoginPage: process.env.SHOW_LOGIN_PAGE === 'true',
+  showLoginPage: process.env.SHOW_LOGIN_PAGE !== 'true',
   cryptoConfig,
 })
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const app = configSpcp(express(), {
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },
-  showLoginPage: process.env.SHOW_LOGIN_PAGE !== 'true',
+  showLoginPage: process.env.SHOW_LOGIN_PAGE === 'true',
   cryptoConfig,
 })
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ const { configSpcp, configMyInfo } = require('./lib/express')
 
 const PORT = process.env.MOCKPASS_PORT || process.env.PORT || 5156
 
+if (!process.env.SINGPASS_ASSERT_ENDPOINT && !process.env.CORPPASS_ASSERT_ENDPOINT) {
+  console.warn('SINGPASS_ASSERT_ENDPOINT or CORPPASS_ASSERT_ENDPOINT is not set. ' +
+    'Value of `PartnerId` request query parameter in redirect URL will be used.'
+  )
+}
+
 const serviceProvider = {
   cert: fs.readFileSync(path.resolve(__dirname, process.env.SERVICE_PROVIDER_CERT_PATH || './static/certs/server.crt')),
   pubKey: fs.readFileSync(path.resolve(__dirname, process.env.SERVICE_PROVIDER_PUB_KEY || './static/certs/key.pub')),

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -52,6 +52,13 @@ const identities = {
   ],
   corpPass: [
     { NRIC: 'S8979373D', UEN: '123456789A' },
+    { NRIC: 'S8116474F', UEN: '123456789A' },
+    { NRIC: 'S8723211E', UEN: '123456789A' },
+    { NRIC: 'S5062854Z', UEN: '123456789B' },
+    { NRIC: 'T0066846F', UEN: '123456789B' },
+    { NRIC: 'F9477325W', UEN: '123456789B' },
+    { NRIC: 'S3000024B', UEN: '123456789C' },
+    { NRIC: 'S6005040F', UEN: '123456789C' },
   ],
 }
 

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -38,6 +38,11 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
             if (assertions.myinfo.personas[id]) {
               id += ' [MyInfo]'
             }
+            if (idp === 'corpPass') {
+              const nric = id.NRIC;
+              const uen = id.UEN;
+              id += ' [NRIC:' + nric + ', UEN:' + uen + ']'
+            }
             return { id, assertURL }
           })
         const response = render(LOGIN_TEMPLATE, values)

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -27,7 +27,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
     app.get(`/${idp.toLowerCase()}/logininitial`, (req, res) => {
       const assertEndpoint = req.query.esrvcID === 'MYINFO-CONSENTPLATFORM' && idp === 'singPass'
         ? MYINFO_ASSERT_ENDPOINT
-        : idpConfig[idp].assertEndpoint
+        : idpConfig[idp].assertEndpoint || req.query.PartnerId
       const relayState = encodeURIComponent(req.query.Target)
       if (showLoginPage) {
         const identities = assertions.identities[idp]

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -31,16 +31,14 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
       const relayState = encodeURIComponent(req.query.Target)
       if (showLoginPage) {
         const identities = assertions.identities[idp]
+        const generateIdFrom = idp === 'corpPass'
+          ? rawId => `${rawId.NRIC} / UEN: ${rawId.UEN}`
+          : rawId => assertions.myinfo.personas[rawId] ? `${rawId} [MyInfo]` : rawId
         const values = identities
-          .map((id, index) => {
+          .map((rawId, index) => {
             const samlArt = encodeURIComponent(samlArtifact(idpConfig[idp].id, index))
             const assertURL = `${assertEndpoint}?SAMLart=${samlArt}&RelayState=${relayState}`
-            if (assertions.myinfo.personas[id]) {
-              id += ' [MyInfo]'
-            }
-            if (idp === 'corpPass') {
-              id = `${id.NRIC} / UEN: ${id.UEN}`
-            }
+            const id = generateIdFrom(rawId)
             return { id, assertURL }
           })
         const response = render(LOGIN_TEMPLATE, values)

--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -39,9 +39,7 @@ function config (app, { showLoginPage, serviceProvider, idpConfig, cryptoConfig 
               id += ' [MyInfo]'
             }
             if (idp === 'corpPass') {
-              const nric = id.NRIC;
-              const uen = id.UEN;
-              id += ' [NRIC:' + nric + ', UEN:' + uen + ']'
+              id = `${id.NRIC} / UEN: ${id.UEN}`
             }
             return { id, assertURL }
           })


### PR DESCRIPTION
This PR allows assertion endpoint to be specified using the `PartnerId` request query parameter, similar to actual SPCP behaviour.

This allow a MockPass deployment to support testing of different IDP URLs simply by varying the `PartnerId` in the URL request query parameter, instead of changing environment variable.

Other improvements:
  * Added additional test accounts
  * Improved 'combobox' values for CorpPass credentials in login page in instead of `[object Object]`.