### PR TITLE
Remove hostPort tech debt

### DIFF
--- a/lib/express/myinfo.js
+++ b/lib/express/myinfo.js
@@ -24,11 +24,6 @@ const authorizations = {}
 function config (app, { serviceProvider, port }) {
   const { verifyMyInfoSignature } = crypto(serviceProvider)
 
-  // HACK: kludge the hostPort together
-  const hostPort = req => ['localhost', '127.0.0.1'].includes(req.hostname)
-    ? `${req.hostname}:${port}`
-    : req.hostname
-
   const lookupPerson = allowedAttributes => (req, res) => {
     const requestedAttributes = (req.query.attributes || '').split(',')
 
@@ -72,7 +67,7 @@ function config (app, { serviceProvider, port }) {
 
       authHeaderFields.httpMethod = req.method
 
-      authHeaderFields.url = `${req.protocol}://${hostPort(req)}${req.baseUrl}${req.path}`
+      authHeaderFields.url = `${req.protocol}://${req.get('host')}${req.baseUrl}${req.path}`
       authHeaderFields.requestedAttributes = req.query.attributes
 
       if (verifyMyInfoSignature(authHeaderFields.signature, authHeaderFields)) {
@@ -153,7 +148,7 @@ function config (app, { serviceProvider, port }) {
         sub: id,
         auth_level: 0,
         scope: req.body.scope.split(' '),
-        iss: `${req.protocol}://${hostPort(req)}/consent/oauth2/consent/myinfo-com`,
+        iss: `${req.protocol}://${req.get('host')}/consent/oauth2/consent/myinfo-com`,
         tokenName: 'access_token',
         token_type: 'Bearer',
         authGrantId: code,
@@ -168,7 +163,7 @@ function config (app, { serviceProvider, port }) {
           ? {
             code,
             ...pick(req.body, ['state', 'scope', 'client_id']),
-            iss: `${req.protocol}://${hostPort(req)}/consent/oauth2/consent/myinfo-com`,
+            iss: `${req.protocol}://${req.get('host')}/consent/oauth2/consent/myinfo-com`,
           }
           : {
             state: req.body.state,


### PR DESCRIPTION
The old approach of adding the hostname and port does not work in a docker-compose network environment. Using express's 'host' param allows us to get both the hostname and port that was used by the request object, solving our problem altogether.