### PR TITLE
fix: id_token serialization format should be in JWE Compact Serialization format

### DIFF
--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -80,7 +80,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       const encryptionKey = await jose.JWK.asKey(serviceProvider.cert, 'pem')
       const idToken = await jose.JWE.createEncrypt(
         { format: 'compact', fields: { cty: 'JWT' } },
-        encryptionKey
+        encryptionKey,
       )
         .update(signedPayload)
         .final()

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -78,7 +78,10 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         .final()
 
       const encryptionKey = await jose.JWK.asKey(serviceProvider.cert, 'pem')
-      const idToken = await jose.JWE.createEncrypt(encryptionKey)
+      const idToken = await jose.JWE.createEncrypt(
+        { format: 'compact', fields: { cty: 'JWT' } },
+        encryptionKey
+      )
         .update(signedPayload)
         .final()
 


### PR DESCRIPTION
Currently the implementation is generating a response where the id_token is in JWE JSON Serialization format
```json
{
   "access_token":"",
   "refresh_token":"refresh",
   "scope":"openid",
   "token_type":"bearer",
   "id_token":{
      "recipients":[
         {
            "encrypted_key":"Y1rLhHgH3MmIpHEduPwZ04OFOoUDLieDsrtKajFNGVJeL6lnB1c-6Emc8uPK9Gmx43M2boHQCGbMEh1hrRIyb2F27MOwD_nBN18BNMFacEEKX5UsU3ItqAhDWkcqg48r3xjD3b2d58Wi5STCP5KizJMxXnBs2qRFZftAdT9pMIQXl3By32iWjdOUtSr7KZq2ZDv6LsODICwkI32Vl1hDDDcp5KdqsBCo4Dz-voVBH-l6-ruAbQTpFlLOfCRWwAO5ZiO2Vx0krUuoFeQf0WL51GAGIb1TUPjI5BqLiJmiaY4E91DveDiQgNwyHxqtgCNU1DZ8a0Yl3KkmUhFoJi04Ww"
         }
      ],
      "protected":"eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJiemEwZFhmNkZqbGExRlFyVkttQVR1WmI5LTRNOTBMeER1ZjN1akxZYnFnIn0",
      "iv":"2ARSycwYYYq2ksbRUGixEQ",
      "ciphertext":"ABHKhXkwxbpyle2oV1S1wNeXXy57nRlB1rsi1iZyN4ez0HDvigWMynByV5mlFv4p250v7ky2R_6zj85JBGiSVyyfKxaI7Z5xP7lnTVzwM3bC9s1uC863RHGX01SZ0QurBvKAgq1EilDcj6JgJxdJkSDkVJIFLUf3CU0CnBEKCG1DoLI2pX2LmA2dr2kV4auqTQmPztb0GadmqwjKs93m6aQcLlY-6RIUHdCCUw5LDmiRFKZxh3bjLRRAIJnXaSykGxz7fk7wuSHyLXeScaCJ_k3Vi3Y1_DTOPh5LYH_3cnC1dCIgP8YUKyhWBh11Il2X-n5swhrIV3dwaSM7ab35PjRKhN6JbEoMIMChQPrtD-PPELMBDSaDBClkR-cP-YrqCabWxN2IdvcDvq3bvILAK4IAcrLAR3TOeIhTE6Iw9SlT7KP9rrbbDkV92vmcIz_tyAEEn46KUyNVeCunQMe2JVCIJJ1XkMEf_3EY53wR86uRT8qjEvVjMCNPzwsBHMz3CgeuH0JhlaNKiy06D4YYHm-2rElfSG9KdotLliAfmmv_PEEN2HF-XF1y1M6XNHu-9hq-dEUxr9wIj074y8SgylbRoTZcuwvjv4wCB_XyLW2k67Vp0AlkjzMB7jIXKnrrfMuYLFV6ubk73VbucnskPiCSkTF90RKcQ6XT8eyrtS7uYDKsc1otpt-k_W4ZJHj6Px0QAQELWHpR3ts-XQWmk-eoDLD0suiu0Ya8QwPjL3uQzY21DEC1G1btLf5z1wqh7JtkGa8WtYoooh_i8tmEiv6skuEfHccMeMga4X7jmKQ",
      "tag":"vgeOmldTs1a7lacteFLGLw"
   }
}
```
This is supposed to be in the JWE Compact Serialization format which is in the form Header.Key.Vector.Payload.Tag and the Content Type should be specified to be JWT.

Below is the sample from the SingPass Login Specifications
```json
{
   "access_token":"f2QROCTT6daaneDKj6D8gDQP3I2Cc3",
   "refresh_token":"yjWLUGVDnyQMnLfKqBErcySXcje3wzXauB35FGW0",
   "id_token":"eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwia2lkIjoidGQzRVRGZXZuWUxGVENDeks0cklIbmVqR3RWZldyZ3U3UUpLU2ZyYWdmNCIsImN0eSI6IkpXVCJ9.eiElCMM1XIge9bopN_-M6ZykUPIhhEuFmkp__ViJ680cNz2hLzoqFU0z88gY6NzyBDhzP8XCiqylOCI45roXPOJgpx244aOF-sn0juQb3nGaAL6wL2eWTYEDrWDDiMcxdsSCT--PwzvDf6N6F3CJNgKhgPDv0WEzHiz0FWrI7AiQM5-3DMsaFx8H3zbUf9QTzjAL_1oApdCuNDksDZEzIpXQZhdIgoL1dAwkyuPMRhKU_sO8a4f5wLh3fpMmHPm5s7WtBbkfggBze6ZXeDi5_zyDvjRZhCMza_QfHrzneQpNgySs6v1ZPyHt0ONi8GAh0l3hzgYxKxjvxyaylW5JtQ.8eY1wqvYBXIJYxrLrpxnZw.oBi27sBL_R-otVr46g29uuWUBCDd9sVa0vfjKjVh9uHyMGNN0vOku1yV4BH7tRm-ClGFFrl_g-H3S0R14gQgXcv6gLubceupBmE6mPWaQwyAlW3yFzvJ_FQRx9y26brrkZIx8ehMx-6UwIeF-bIznLkCqBEyp5eE47VmN817PkvCoN4NckUmlSljTSejKNB8I_Y4l6FiEkb02XBHxbhdFRnMwRUNW8Uiadny8qXT4kRHTkCqwxpCm0bGwOIXQr-0x203Rp4Dzu1Aw9VSdmuyAbwLvp503GwdBo1Pe0ABi2RA8clPxroKYxfoz0VYRgnlJRvn-z62uEXsEfBaZ7AdOGC9mravC7EogDqobEjvSbT8TFDPkYB4EmV061ZfUe8pnr13ID0t2NuELETAejXfCMiYTg0hB9HB7dlk-zh5d19Dqcxo4if_MaYKrtLeVh-CJCgU24VBZGpdQNuG0ZodmrFNJsIoi-f7ragobCxv2S4Y-fbCCSuHQWbwpgQcBXSAFwhwPDoX0u-1Fh8nJlr2-uo3EoLae36Zmyl7F8ndLIzx1iHg3J2tfOYFExeByquNRGfqto6L6kRzzjnBl-NOzwCx51dD6IIKZmrHbZNbWgdPcuqeoc4gL1ciCjwm4gQk-bdwg0JkInKOULO6gf47gPjkz6owlBHoH9P_Qp4p6Frh5zW87hpzPC7RMUAvwFrWn74VYqQK1GhUiktlYG8ys-ek5GNsbxD7n2urmN6NfQOJ8SZ83ewoTHcRC1gN9F8w9QeOoqsCUt76Aupze5c614tudIAHUJL1i00oMevNWWm9pb3OlVGENtUrMf5HYPHuIn6C57BuXVtEkiWZA6SQ-KgJ29NKhUY3nItpvzKrhWpn1tysFtPP_oNIKIcgBqXltDSjLzJ8BNfhZdMrRJwosZm4t4I9v98Yvj35nWFA-gxGl8uqt-MZ4D3-on4P0lSRjknqeNClx4qb6ilEniR3i8BW7ktvBbpN8ueicS47_H0.-E6iFnM-mX7W2VeDmO1WDXSM2Wvi_PqwRmU50ATgAKk",
   "token_type":"bearer",
   "expires_in":600,
   "scope":"openid"
}
```
The sample id_token has the Header value of `{"alg":"RSA-OAEP-256","enc":"A256CBC-HS512","kid":"td3ETFevnYLFTCCzK4rIHnejGtVfWrgu7QJKSfragf4","cty":"JWT"}`