### PR TITLE
feat: add nonce handling for oidc authentication request

### DIFF
--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -12,10 +12,14 @@ const LOGIN_TEMPLATE = fs.readFileSync(
   'utf8',
 )
 
+const NONCE_TIMEOUT = 5 * 60 * 1000
+const nonceStore = new Map()
+
 function config(app, { showLoginPage, idpConfig, serviceProvider }) {
   app.get('/singpass/authorize', (req, res) => {
     const redirectURI = req.query.redirect_uri
     const state = encodeURIComponent(req.query.state)
+    const nonceExpiry = Date.now() + NONCE_TIMEOUT
     if (showLoginPage) {
       const oidc = assertions.oidc.singPass
       const generateIdFrom = (rawId) =>
@@ -24,6 +28,9 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         const code = encodeURIComponent(
           samlArtifact(idpConfig.singPass.id, index),
         )
+        if (req.query.nonce) {
+          nonceStore.set(code, { nonce: req.query.nonce, expires: nonceExpiry })
+        }
         const assertURL = `${redirectURI}?code=${code}&state=${state}`
         const id = generateIdFrom(rawId)
         return { id, assertURL }
@@ -32,6 +39,9 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       res.send(response)
     } else {
       const code = encodeURIComponent(samlArtifact(idpConfig.singPass.id))
+      if (req.query.nonce) {
+        nonceStore.set(code, { nonce: req.query.nonce, expires: nonceExpiry })
+      }
       const assertURL = `${redirectURI}?code=${code}&state=${state}`
       console.warn(
         `Redirecting login from ${req.query.client_id} to ${redirectURI}`,
@@ -54,16 +64,19 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       const nric = assertions.oidc.singPass[uuid]
       const sub = `s=${nric},u=${uuid}`
 
+      const nonceEntry = nonceStore.get(encodeURIComponent(artifact))
+      const nonce = nonceEntry ? nonceEntry.nonce : undefined
+
       const payload = {
         rt_hash: '',
         at_hash: '',
-        // TODO: Figure a way to return the nonce
         iat: Date.now(),
         exp: Date.now() + 24 * 60 * 60 * 1000,
         iss: req.get('host'),
         amr: ['pwd'],
         aud,
         sub,
+        ...(nonce && { nonce }),
       }
 
       const signingPem = fs.readFileSync(
@@ -91,6 +104,13 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         scope: 'openid',
         token_type: 'bearer',
         id_token: idToken,
+      })
+
+      const now = Date.now()
+      nonceStore.forEach((value, key) => {
+        if (now > value.expires) {
+          nonceStore.delete(key)
+        }
       })
     },
   )

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const { render } = require('mustache')
 const jose = require('node-jose')
 const path = require('path')
+const ExpiryMap = require('expiry-map')
 
 const assertions = require('../assertions')
 const samlArtifact = require('../saml-artifact')
@@ -11,15 +12,13 @@ const LOGIN_TEMPLATE = fs.readFileSync(
   path.resolve(__dirname, '../../static/html/login-page.html'),
   'utf8',
 )
-
 const NONCE_TIMEOUT = 5 * 60 * 1000
-const nonceStore = new Map()
+const nonceStore = new ExpiryMap(NONCE_TIMEOUT)
 
 function config(app, { showLoginPage, idpConfig, serviceProvider }) {
   app.get('/singpass/authorize', (req, res) => {
     const redirectURI = req.query.redirect_uri
     const state = encodeURIComponent(req.query.state)
-    const nonceExpiry = Date.now() + NONCE_TIMEOUT
     if (showLoginPage) {
       const oidc = assertions.oidc.singPass
       const generateIdFrom = (rawId) =>
@@ -29,7 +28,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
           samlArtifact(idpConfig.singPass.id, index),
         )
         if (req.query.nonce) {
-          nonceStore.set(code, { nonce: req.query.nonce, expires: nonceExpiry })
+          nonceStore.set(code, req.query.nonce)
         }
         const assertURL = `${redirectURI}?code=${code}&state=${state}`
         const id = generateIdFrom(rawId)
@@ -40,7 +39,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
     } else {
       const code = encodeURIComponent(samlArtifact(idpConfig.singPass.id))
       if (req.query.nonce) {
-        nonceStore.set(code, { nonce: req.query.nonce, expires: nonceExpiry })
+        nonceStore.set(code, req.query.nonce)
       }
       const assertURL = `${redirectURI}?code=${code}&state=${state}`
       console.warn(
@@ -64,8 +63,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       const nric = assertions.oidc.singPass[uuid]
       const sub = `s=${nric},u=${uuid}`
 
-      const nonceEntry = nonceStore.get(encodeURIComponent(artifact))
-      const nonce = nonceEntry ? nonceEntry.nonce : undefined
+      const nonce = nonceStore.get(encodeURIComponent(artifact))
 
       const payload = {
         rt_hash: '',
@@ -104,13 +102,6 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         scope: 'openid',
         token_type: 'bearer',
         id_token: idToken,
-      })
-
-      const now = Date.now()
-      nonceStore.forEach((value, key) => {
-        if (now > value.expires) {
-          nonceStore.delete(key)
-        }
       })
     },
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,7 +226,8 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-8.3.4.tgz",
       "integrity": "sha512-f4HigYjeIBn9f7OuNv5zh2y5vWaAhNFrfeul8CRJDy82l3Y+09lxOTGxfF3uMXKrZq4LmuK6qvvRCZ8mUrVvzQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@commitlint/format": {
       "version": "9.1.1",
@@ -272,6 +273,7 @@
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-8.3.5.tgz",
       "integrity": "sha512-poF7R1CtQvIXRmVIe63FjSQmN9KDqjRtU5A6hxqXBga87yB2VUJzic85TV6PcQc+wStk52cjrMI+g0zFx+Zxrw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@commitlint/execute-rule": "^8.3.4",
         "@commitlint/resolve-extends": "^8.3.5",
@@ -287,6 +289,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -297,13 +300,15 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -339,6 +344,7 @@
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-8.3.5.tgz",
       "integrity": "sha512-nHhFAK29qiXNe6oH6uG5wqBnCR+BQnxlBW/q5fjtxIaQALgfoNLHwLS9exzbIRFqwJckpR6yMCfgMbmbAOtklQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "import-fresh": "^3.0.0",
         "lodash": "4.17.15",
@@ -350,13 +356,15 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -928,6 +936,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1221,6 +1230,7 @@
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "callsites": "^2.0.0"
       },
@@ -1229,7 +1239,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1238,6 +1249,7 @@
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -1867,7 +1879,8 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1880,6 +1893,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
@@ -1892,6 +1906,7 @@
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -1902,6 +1917,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -1911,7 +1927,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2452,6 +2469,14 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "expiry-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expiry-map/-/expiry-map-1.1.0.tgz",
+      "integrity": "sha512-EviBh1pKXf8TuPIf88HS27Ti2biOZA1Ci4FeWhXzgY/tCBv05FA+7gO0jXt7AF5JgaiReAld1ag3jd5vzvKupw==",
+      "requires": {
+        "map-age-cleaner": "^0.1.0"
       }
     },
     "express": {
@@ -3291,7 +3316,8 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3907,6 +3933,14 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -4634,6 +4668,11 @@
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -5018,7 +5057,8 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "base-64": "^0.1.0",
     "cookie-parser": "^1.4.3",
     "dotenv": "^8.1.0",
+    "expiry-map": "^1.1.0",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
Add basic support for handling the nonce sent with the oidc authentication request by setting it in the token response.

This implementation stores the nonce keyed by authorization codes that is generated by the server in memory. The nonces will be cleared from memory after 5 minutes from the authentication request after the next token response is issued by the server.