### PR TITLE
fix(oidc): fix token values to pass relying party validations

### DIFF
--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -70,7 +70,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         at_hash: '',
         iat: Date.now(),
         exp: Date.now() + 24 * 60 * 60 * 1000,
-        iss: req.get('host'),
+        iss: `${req.protocol}://${req.get('host')}`,
         amr: ['pwd'],
         aud,
         sub,
@@ -97,7 +97,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         .final()
 
       res.send({
-        access_token: '',
+        access_token: 'access',
         refresh_token: 'refresh',
         scope: 'openid',
         token_type: 'bearer',


### PR DESCRIPTION
**Background**
Using Spring Security's OpenID Connect support for building a web application.

**Issue**
Spring Security's OpenID Connect support throws exceptions when handling the token response from mockpass.

**Fixes**
- According to the spec the issuer should be a uri "contains scheme, host, and optionally, port number and path components and no query or fragment components". So the code was changed to include the scheme.
- The Spring Security implementation currently throws an exception if the access_token is empty. So the code was changed to a hardcoded value 'access'. Not sure if this will impact other relying party implementations.
