### PR TITLE
Simplesamlphp integration fixes

### DIFF
--- a/lib/express/spcp.js
+++ b/lib/express/spcp.js
@@ -38,7 +38,7 @@ function config(
         req.query.esrvcID === 'MYINFO-CONSENTPLATFORM' && idp === 'singPass'
           ? MYINFO_ASSERT_ENDPOINT
           : idpConfig[idp].assertEndpoint || req.query.PartnerId
-      const relayState = encodeURIComponent(req.query.Target)
+      const relayState = req.query.Target
       if (showLoginPage) {
         const saml = assertions.saml[idp]
         const generateIdFrom =
@@ -52,7 +52,10 @@ function config(
           const samlArt = encodeURIComponent(
             samlArtifact(idpConfig[idp].id, index),
           )
-          const assertURL = `${assertEndpoint}?SAMLart=${samlArt}&RelayState=${relayState}`
+          let assertURL = `${assertEndpoint}?SAMLart=${samlArt}`
+          if (relayState !== undefined) {
+            assertURL += `&RelayState=${encodeURIComponent(relayState)}`
+          }
           const id = generateIdFrom(rawId)
           return { id, assertURL }
         })
@@ -60,7 +63,10 @@ function config(
         res.send(response)
       } else {
         const samlArt = encodeURIComponent(samlArtifact(idpConfig[idp].id))
-        const assertURL = `${assertEndpoint}?SAMLart=${samlArt}&RelayState=${relayState}`
+        let assertURL = `${assertEndpoint}?SAMLart=${samlArt}`
+        if (relayState !== undefined) {
+          assertURL += `&RelayState=${encodeURIComponent(relayState)}`
+        }
         console.warn(
           `Redirecting login from ${req.query.PartnerId} to ${assertURL}`,
         )

--- a/static/saml/unsigned-response.xml
+++ b/static/saml/unsigned-response.xml
@@ -4,6 +4,9 @@
     <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" 
       xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="{{destination}}" InResponseTo="{{inResponseTo}}">
       <saml:Issuer>{{issuer}}</saml:Issuer>
+      <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+      </samlp:Status>
       <samlp:Response ID="_8e8dc5f69a98cc4222227e5ce34606fd672f91e6" Version="2.0" IssueInstant="{{issueInstant}}" Destination="{{destination}}">
         <saml:Issuer>{{issuer}}</saml:Issuer>
         <samlp:Status>


### PR DESCRIPTION
Hi,

We're working on SingPass integration in our LMS, and we've used mockpass to get working prototype.
Our LMS uses [simplesamlphp library](https://github.com/simplesamlphp/simplesamlphp) v1.18.7.
During prototyping, I've found two issues in mockpass which affect simplesamlphp SAML implementation:
- `samlp:ArtifactResponse` should have two `Status` elements - one is `Response` child, another is in `ArtifactResponse` - see SAML standard, e.g. https://logius.nl/sites/default/files/public/bestanden/diensten/Routeringsvoorziening/eID%20SAML%204.4%20-%20Specification-v8-20200309_110046.pdf
- `RelayState` query parameters becomes `"undefined"` when service provider doesn't send `Target` parameter - but it should be skipped instead

This PR fixes simplesamlphp integration issues.