### PR TITLE
add form for custom NRIC for singpass login (SAML)

### DIFF
--- a/lib/express/myinfo/consent.js
+++ b/lib/express/myinfo/consent.js
@@ -54,20 +54,26 @@ const authorizeViaOIDC = authorize(
 function config(app) {
   app.get(MYINFO_ASSERT_ENDPOINT, (req, res) => {
     const rawArtifact = req.query.SAMLart || req.query.code
-    const state = req.query.RelayState || req.query.state
     const artifact = rawArtifact.replace(/ /g, '+')
     const artifactBuffer = Buffer.from(artifact, 'base64')
     let index = artifactBuffer.readInt8(artifactBuffer.length - 1)
 
-    const assertionType = req.query.code ? 'oidc' : 'saml'
+    const state = req.query.RelayState || req.query.state
+    let id
+    const isRawNRIC = rawArtifact.length === 9
+    if (isRawNRIC) {
+      id = rawArtifact
+    } else {
+      const assertionType = req.query.code ? 'oidc' : 'saml'
 
-    // use env NRIC when SHOW_LOGIN_PAGE is false
-    if (index === -1) {
-      index = assertions[assertionType].singPass.indexOf(
-        assertions.singPassNric,
-      )
+      // use env NRIC when SHOW_LOGIN_PAGE is false
+      if (index === -1) {
+        index = assertions[assertionType].singPass.indexOf(
+          assertions.singPassNric,
+        )
+      }
+      id = assertions[assertionType].singPass[index]
     }
-    const id = assertions[assertionType].singPass[index]
     const persona = assertions.myinfo[req.query.code ? 'v3' : 'v2'].personas[id]
     if (!persona) {
       res.status(404).send({

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -39,7 +39,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
           const id = idGenerator[idp](rawId)
           return { id, assertURL }
         })
-        const response = render(LOGIN_TEMPLATE, values)
+        const response = render(LOGIN_TEMPLATE, { values })
         res.send(response)
       } else {
         const code = encodeURIComponent(samlArtifact(idpConfig[idp].id))

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -96,9 +96,9 @@ function config(
           )
           console.warn(`Received SAML Artifact ${samlArtifact}`)
           let nric = samlArtifact
-
-          // if not custom NRIC,
-          if (samlArtifact.length > 9) {
+          const isRawNRIC = samlArtifact.length === 9
+          if (!isRawNRIC) {
+            // Handle encoded base64 Artifact
             // Take the template and plug in the typical SingPass/CorpPass response
             // Sign and encrypt the assertion
             const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -58,7 +58,11 @@ function config(
           const id = idGenerator[idp](rawId)
           return { id, assertURL }
         })
-        const response = render(LOGIN_TEMPLATE, { values, assertEndpoint })
+        const response = render(LOGIN_TEMPLATE, {
+          values,
+          assertEndpoint,
+          relayState,
+        })
         res.send(response)
       } else {
         const samlArt = encodeURIComponent(samlArtifact(idpConfig[idp].id))

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -58,7 +58,7 @@ function config(
           const id = idGenerator[idp](rawId)
           return { id, assertURL }
         })
-        const response = render(LOGIN_TEMPLATE, values)
+        const response = render(LOGIN_TEMPLATE, { values, assertEndpoint })
         res.send(response)
       } else {
         const samlArt = encodeURIComponent(samlArtifact(idpConfig[idp].id))
@@ -95,18 +95,25 @@ function config(
             xml,
           )
           console.warn(`Received SAML Artifact ${samlArtifact}`)
-          // Take the template and plug in the typical SingPass/CorpPass response
-          // Sign and encrypt the assertion
-          const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
-          let index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
-          // use env NRIC when SHOW_LOGIN_PAGE is false
-          if (index === -1) {
-            index =
-              idp === 'singPass'
-                ? assertions.saml.singPass.indexOf(assertions.singPassNric)
-                : assertions.saml.corpPass.findIndex(
-                    (c) => c.nric === assertions.corpPassNric,
-                  )
+          let nric = samlArtifact
+
+          // if not custom NRIC,
+          if (samlArtifact.length > 9) {
+            // Take the template and plug in the typical SingPass/CorpPass response
+            // Sign and encrypt the assertion
+            const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
+            let index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
+            // use env NRIC when SHOW_LOGIN_PAGE is false
+            if (index === -1) {
+              index =
+                idp === 'singPass'
+                  ? assertions.saml.singPass.indexOf(assertions.singPassNric)
+                  : assertions.saml.corpPass.findIndex(
+                      (c) => c.nric === assertions.corpPassNric,
+                    )
+            }
+
+            nric = assertions.saml[idp][index]
           }
 
           const samlArtifactResolveId = xpath.select(
@@ -115,7 +122,7 @@ function config(
           )
 
           let result = assertions.saml.create[idp](
-            assertions.saml[idp][index],
+            nric,
             idpConfig[idp].id,
             idpConfig[idp].assertEndpoint,
             samlArtifactResolveId,

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -102,7 +102,9 @@ function config(
             // Take the template and plug in the typical SingPass/CorpPass response
             // Sign and encrypt the assertion
             const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
-            let index = samlArtifactBuffer.readInt8(samlArtifactBuffer.length - 1)
+            let index = samlArtifactBuffer.readInt8(
+              samlArtifactBuffer.length - 1,
+            )
             // use env NRIC when SHOW_LOGIN_PAGE is false
             if (index === -1) {
               index =

--- a/static/html/login-page.html
+++ b/static/html/login-page.html
@@ -170,27 +170,35 @@
                                                                 Select username
                                                                 </button>
                                                                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                                                                    {{#.}}
+                                                                    {{#values}}
                                                                         <li><a href = "{{ assertURL }}">{{ id }}</a></li>
-                                                                    {{/.}}
-                                                                </div>
-                                                            </div>
-                                                            <br>
-                                                            <div class="clearfix"></div>
-                                                            <div class="login__footer">
-                                                                <div class="login-note">
-                                                                     Forgot <a aria-label="Forgot MockPass ID">MockPass ID</a> or <a aria-label="Forgot password">password</a>?
-                                                                </div>
-                                                                <div class="sp-reglink">
-                                                                    Don't have an account? <a aria-label="Register now">Register now</a>
+                                                                    {{/values}}
                                                                 </div>
                                                             </div>
                                                         </div>
-
                                                     <div>
 
                                                     <input type="hidden" name="CSRFToken" value="null" />
                                                     </div>
+                                                    </form>
+                                                    <form action="{{assertEndpoint}}" method="get">
+                                                        <br>
+                                                        {{#assertEndpoint}}
+                                                            <h6>or with your own user</h6>
+                                                            <br>
+                                                            <input maxlength="9" name="SAMLart" placeholder="NRIC" value="S1234567A" style="width: 100%; border: 2px solid #ccc; border-radius: 5px; background: white; color: rgb(42, 45, 51); text-align: left;">
+                                                            <button autofocus="" type="submit">Login</button>
+                                                            <br>
+                                                            <br>
+                                                        {{/assertEndpoint}}
+                                                        <div class="login__footer">
+                                                            <div class="login-note">
+                                                                 Forgot <a aria-label="Forgot MockPass ID">MockPass ID</a> or <a aria-label="Forgot password">password</a>?
+                                                            </div>
+                                                            <div class="sp-reglink">
+                                                                Don't have an account? <a aria-label="Register now">Register now</a>
+                                                            </div>
+                                                        </div>                                                        
                                                     </form>
                                                 </div>
                                                 <div class="clearfix"></div>

--- a/static/html/login-page.html
+++ b/static/html/login-page.html
@@ -186,6 +186,7 @@
                                                         {{#assertEndpoint}}
                                                             <h6>or with your own user</h6>
                                                             <br>
+                                                            <input type="hidden" name="RelayState" value="{{ relayState }}" />
                                                             <input maxlength="9" name="SAMLart" placeholder="NRIC" value="S1234567A" style="width: 100%; border: 2px solid #ccc; border-radius: 5px; background: white; color: rgb(42, 45, 51); text-align: left;">
                                                             <button autofocus="" type="submit">Login</button>
                                                             <br>


### PR DESCRIPTION
This PR aims to add functionality to allow users to key in a custom NRIC instead of using the predefined ones. (SAML-only)
The use-case is that the SP may already have seeded data that uses different NRICs from the ones provided in mockpass, so it would be nice for a custom input.

I'm relatively new to SAML, and the code is the shortest path I could think of to achieve this functionality - please let me know if it is necessary to generate and read SAML Artifacts for this feature, thanks!