### PR TITLE
feat: Add expires_in to POST /token response

### DIFF
--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -105,6 +105,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
         res.send({
           access_token: accessToken,
           refresh_token: 'refresh',
+          expires_in: 24 * 60 * 60,
           scope: 'openid',
           token_type: 'bearer',
           id_token: idToken,


### PR DESCRIPTION
Per the documentation here: https://public.cloud.myinfo.gov.sg/sglogin/SingPass-login-specs-v0.1.html#operation/tokenAuth

The token endpoint returns an expires_in in the response, so i've added the expires_in of 1 day in seconds (to be consistent with the token lifespan)
