### PR TITLE
feat: add refresh_token and rt_hash to singpass oidc

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -15,9 +15,9 @@ const defaultAudience =
   process.env.SERVICE_PROVIDER_ENTITY_ID ||
   'http://sp.example.com/demo1/metadata.php'
 
-const hashAccessToken = (accessToken) => {
+const hashToken = (token) => {
   const fullHash = crypto.createHash('sha256')
-  fullHash.update(accessToken, 'utf8')
+  fullHash.update(token, 'utf8')
   const fullDigest = fullHash.digest()
   return fullDigest.slice(0, fullDigest.length / 2).toString('base64')
 }
@@ -207,12 +207,15 @@ const oidc = {
       const sub = `s=${nric},u=${uuid}`
 
       const accessToken = crypto.randomBytes(15).toString('hex')
-      const accessTokenHash = hashAccessToken(accessToken)
+      const refreshToken = crypto.randomBytes(20).toString('hex')
+      const accessTokenHash = hashToken(accessToken)
+      const refreshTokenHash = hashToken(refreshToken)
 
       return {
         accessToken,
+        refreshToken,
         idTokenClaims: {
-          rt_hash: '',
+          rt_hash: refreshTokenHash,
           at_hash: accessTokenHash,
           iat: Date.now(),
           exp: Date.now() + 24 * 60 * 60 * 1000,
@@ -255,9 +258,10 @@ const oidc = {
         .update(JSON.stringify(accessTokenClaims))
         .final()
 
-      const accessTokenHash = hashAccessToken(accessToken)
+      const accessTokenHash = hashToken(accessToken)
 
       return {
+        refreshToken: 'refresh',
         accessToken,
         idTokenClaims: {
           ...baseClaims,

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -79,9 +79,16 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
 
         const nonce = nonceStore.get(encodeURIComponent(artifact))
 
-        const { idTokenClaims, accessToken } = await assertions.oidc.create[
-          idp
-        ](uuid, `${req.protocol}://${req.get('host')}`, aud, nonce)
+        const {
+          idTokenClaims,
+          accessToken,
+          refreshToken,
+        } = await assertions.oidc.create[idp](
+          uuid,
+          `${req.protocol}://${req.get('host')}`,
+          aud,
+          nonce,
+        )
 
         const signingPem = fs.readFileSync(
           path.resolve(__dirname, '../../static/certs/spcp-key.pem'),
@@ -104,7 +111,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
 
         res.send({
           access_token: accessToken,
-          refresh_token: 'refresh',
+          refresh_token: refreshToken,
           expires_in: 24 * 60 * 60,
           scope: 'openid',
           token_type: 'bearer',


### PR DESCRIPTION
Reference: https://public.cloud.myinfo.gov.sg/sglogin/SingPass-login-specs-v0.1.html

- Adds refresh_token based on specification for Singpass OIDC (40 chars long)
- Adds rt_hash so that the refresh token can be validated against at the RP before refreshing the token, as recommended by the docs