### PR TITLE
fix: change error_description to error-description

### DIFF
--- a/lib/express/myinfo/consent.js
+++ b/lib/express/myinfo/consent.js
@@ -140,7 +140,8 @@ function config(app) {
             }
           : {
               state: req.body.state,
-              error_description: 'Resource Owner did not authorize the request',
+              'error-description':
+                'Resource Owner did not authorize the request',
               error: 'access_denied',
             },
       )


### PR DESCRIPTION
## Problem

When there is an error during the MyInfo consent flow, e.g. if the user does not provide consent, MyInfo returns `error-description` (note hyphen) in the query params, as shown in the screenshots below. However, Mockpass returns `error_description` (note underscore).

### Production
![image](https://user-images.githubusercontent.com/29480346/110411936-5d2c5b00-80c6-11eb-8725-2fd9cfc78f45.png)

### Staging
![image](https://user-images.githubusercontent.com/29480346/110411948-61587880-80c6-11eb-827c-82c2414d8617.png)

### Sandbox
![image](https://user-images.githubusercontent.com/29480346/110411973-6fa69480-80c6-11eb-8939-42e8e8748564.png)

## Solution

Change `error_description` to `error-description`.