### PR TITLE
Adds handling of grant_type=refresh_token to token endpoint (oidc)

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -15,6 +15,17 @@ const defaultAudience =
   process.env.SERVICE_PROVIDER_ENTITY_ID ||
   'http://sp.example.com/demo1/metadata.php'
 
+const createRefreshToken = (uuid) => {
+  const prefixSize = (`${uuid}`.length + 1) / 2
+  const padding = Number.isInteger(prefixSize) ? '/' : '/f'
+
+  return (
+    uuid +
+    padding +
+    crypto.randomBytes(20 - Math.floor(prefixSize)).toString('hex')
+  )
+}
+
 const hashToken = (token) => {
   const fullHash = crypto.createHash('sha256')
   fullHash.update(token, 'utf8')
@@ -207,7 +218,7 @@ const oidc = {
       const sub = `s=${nric},u=${uuid}`
 
       const accessToken = crypto.randomBytes(15).toString('hex')
-      const refreshToken = crypto.randomBytes(20).toString('hex')
+      const refreshToken = createRefreshToken(uuid)
       const accessTokenHash = hashToken(accessToken)
       const refreshTokenHash = hashToken(refreshToken)
 

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -73,17 +73,17 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
           )
           const artifactBuffer = Buffer.from(artifact, 'base64')
           uuid = artifactBuffer.readInt8(artifactBuffer.length - 1)
-          // use env NRIC when SHOW_LOGIN_PAGE is false
-          if (uuid === -1) {
-            uuid =
-              idp === 'singPass'
-                ? assertions.oidc.singPass.indexOf(assertions.singPassNric)
-                : assertions.oidc.corpPass.findIndex(
-                    (c) => c.nric === assertions.corpPassNric,
-                  )
-          }
-
           nonce = nonceStore.get(encodeURIComponent(artifact))
+        }
+
+        // use env NRIC when SHOW_LOGIN_PAGE is false
+        if (uuid === -1) {
+          uuid =
+            idp === 'singPass'
+              ? assertions.oidc.singPass.indexOf(assertions.singPassNric)
+              : assertions.oidc.corpPass.findIndex(
+                  (c) => c.nric === assertions.corpPassNric,
+                )
         }
 
         const {

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -58,26 +58,33 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       `/${idp.toLowerCase()}/token`,
       bodyParser.urlencoded({ extended: false }),
       async (req, res) => {
-        const { client_id: aud, code: artifact } = req.body
-        console.warn(
-          `Received artifact ${artifact} from ${aud} and ${req.body.redirect_uri}`,
-        )
+        const { client_id: aud, grant_type: grant } = req.body
+        let nonce, uuid
 
-        const artifactBuffer = Buffer.from(artifact, 'base64')
+        if (grant === 'refresh_token') {
+          const { refresh_token: refreshToken } = req.body
+          console.warn(`Refreshing tokens with ${refreshToken}`)
 
-        let uuid = artifactBuffer.readInt8(artifactBuffer.length - 1)
+          uuid = refreshToken.split('/')[0]
+        } else {
+          const { code: artifact } = req.body
+          console.warn(
+            `Received artifact ${artifact} from ${aud} and ${req.body.redirect_uri}`,
+          )
+          const artifactBuffer = Buffer.from(artifact, 'base64')
+          uuid = artifactBuffer.readInt8(artifactBuffer.length - 1)
+          // use env NRIC when SHOW_LOGIN_PAGE is false
+          if (uuid === -1) {
+            uuid =
+              idp === 'singPass'
+                ? assertions.oidc.singPass.indexOf(assertions.singPassNric)
+                : assertions.oidc.corpPass.findIndex(
+                    (c) => c.nric === assertions.corpPassNric,
+                  )
+          }
 
-        // use env NRIC when SHOW_LOGIN_PAGE is false
-        if (uuid === -1) {
-          uuid =
-            idp === 'singPass'
-              ? assertions.oidc.singPass.indexOf(assertions.singPassNric)
-              : assertions.oidc.corpPass.findIndex(
-                  (c) => c.nric === assertions.corpPassNric,
-                )
+          nonce = nonceStore.get(encodeURIComponent(artifact))
         }
-
-        const nonce = nonceStore.get(encodeURIComponent(artifact))
 
         const {
           idTokenClaims,


### PR DESCRIPTION
Adds functionality when "grant_type=refresh_token" so that the tokens can be refreshed on the `/token` endpoint, in addition to the current functionality of creating tokens on first login. 

This is based on https://public.cloud.myinfo.gov.sg/sglogin/SingPass-login-specs-v0.1.html

Prefixes refresh_token with uuid for simplicity's sake so that we can retrieve the corresponding nric for the new tokens.
- This is separated by '/' (with an additional padding of 'f' if the uuid is an even number, so to keep with the length of 40 characters (20 bytes))