### PR TITLE
fix: make ID token time claims spec compliant

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -240,8 +240,8 @@ const oidc = {
         idTokenClaims: {
           rt_hash: refreshTokenHash,
           at_hash: accessTokenHash,
-          iat: Date.now(),
-          exp: Date.now() + 24 * 60 * 60 * 1000,
+          iat: Math.floor(Date.now() / 1000),
+          exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
           iss,
           amr: ['pwd'],
           aud,
@@ -252,8 +252,8 @@ const oidc = {
     },
     corpPass: async (uuid, iss, aud, nonce) => {
       const baseClaims = {
-        iat: Date.now(),
-        exp: Date.now() + 24 * 60 * 60 * 1000,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
         iss,
         aud,
       }


### PR DESCRIPTION
According to spec, `iat` and `exp` should be `NumericDate`s, i.e. number of seconds (not millis) from epoch.

Ref: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1