### PR TITLE
fix(sgid): use compact encrypt for jwe, modify jwt sub

### DIFF
--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -92,6 +92,9 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
             nonce,
             accessToken,
           )
+        // Change sub from `s=${nric},u=${uuid}`
+        // to `u=${uuid}` to be consistent with userinfo sub
+        idTokenClaims.sub = idTokenClaims.sub.split(',')[1]
 
         const signingKey = await jose.JWK.asKey(signingPem, 'pem')
         const idToken = await jose.JWS.createSign(
@@ -106,7 +109,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
           refresh_token: refreshToken,
           expires_in: 24 * 60 * 60,
           scope: 'openid',
-          token_type: 'bearer',
+          token_type: 'Bearer',
           id_token: idToken,
         })
       } catch (error) {
@@ -129,13 +132,22 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       alg: 'A256GCM',
     })
 
-    const encryptedNric = await jose.JWE.createEncrypt(payloadKey)
+    const encryptedNric = await jose.JWE.createEncrypt(
+      { format: 'compact' },
+      payloadKey,
+    )
       .update(nric)
       .final()
-    const encryptedName = await jose.JWE.createEncrypt(payloadKey)
+    const encryptedName = await jose.JWE.createEncrypt(
+      { format: 'compact' },
+      payloadKey,
+    )
       .update(name)
       .final()
-    const encryptedDateOfBirth = await jose.JWE.createEncrypt(payloadKey)
+    const encryptedDateOfBirth = await jose.JWE.createEncrypt(
+      { format: 'compact' },
+      payloadKey,
+    )
       .update(dateOfBirth)
       .final()
     const data = {
@@ -143,11 +155,14 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       'myinfo.name': encryptedName,
       'myinfo.date_of_birth': encryptedDateOfBirth,
     }
-    const encryptionKey = await jose.JWK.asKey(serviceProvider.cert, 'pem')
+    const encryptionKey = await jose.JWK.asKey(serviceProvider.pubKey, 'pem')
 
     const plaintextPayloadKey = JSON.stringify(payloadKey.toJSON(true))
     console.log(plaintextPayloadKey)
-    const encryptedPayloadKey = await jose.JWE.createEncrypt(encryptionKey)
+    const encryptedPayloadKey = await jose.JWE.createEncrypt(
+      { format: 'compact' },
+      encryptionKey,
+    )
       .update(plaintextPayloadKey)
       .final()
     res.json({


### PR DESCRIPTION
## Problem

- SGID uses JWE compact encryption. 
- The sub should be consistent between access token and id token.
- SGID encrypts myinfo details using the client-provided public key.

## Solution

- Use JWE compact encrpytion format.
- Align sub to be the same for both id token and access token
- Use client-provided `key.pub` to encrypt myinfo details.

