### PR TITLE
feat: allow overriding `showLoginPage` config via request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ export MOCKPASS_PORT=5156
 $ export MOCKPASS_NRIC=S8979373D
 $ export MOCKPASS_UEN=123456789A
 
-$ export SHOW_LOGIN_PAGE=true # Optional, defaults to `false`
+$ export SHOW_LOGIN_PAGE=true # Optional, defaults to `false`; can be overridden per request using `X-Show-Login-Page` HTTP header
 
 # Disable signing/encryption (Optional, by default `true`)
 $ export SIGN_ASSERTION=false

--- a/index.js
+++ b/index.js
@@ -61,7 +61,12 @@ const options = {
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },
-  showLoginPage: process.env.SHOW_LOGIN_PAGE === 'true',
+  showLoginPage: (req) => {
+    if (req.header('X-Show-Login-Page')) {
+      return req.header('X-Show-Login-Page') === 'true'
+    }
+    return process.env.SHOW_LOGIN_PAGE === 'true'
+  },
   encryptMyInfo: process.env.ENCRYPT_MYINFO === 'true',
   cryptoConfig,
 }

--- a/index.js
+++ b/index.js
@@ -62,10 +62,7 @@ const options = {
     },
   },
   showLoginPage: (req) => {
-    if (req.header('X-Show-Login-Page')) {
-      return req.header('X-Show-Login-Page') === 'true'
-    }
-    return process.env.SHOW_LOGIN_PAGE === 'true'
+    return process.env.SHOW_LOGIN_PAGE === 'true' || req.header('X-Show-Login-Page') === 'true'
   },
   encryptMyInfo: process.env.ENCRYPT_MYINFO === 'true',
   cryptoConfig,

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -30,7 +30,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
     app.get(`/${idp.toLowerCase()}/authorize`, (req, res) => {
       const redirectURI = req.query.redirect_uri
       const state = encodeURIComponent(req.query.state)
-      if (showLoginPage) {
+      if (showLoginPage(req)) {
         const oidc = assertions.oidc[idp]
         const values = oidc.map((rawId, index) => {
           const code = encodeURIComponent(

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -45,7 +45,7 @@ function config(
           : idpConfig[idp].assertEndpoint || req.query.PartnerId
       const relayState = req.query.Target
       const partnerId = idpConfig[idp].id
-      if (showLoginPage) {
+      if (showLoginPage(req)) {
         const saml = assertions.saml[idp]
         const values = saml.map((rawId, index) => {
           const samlArt = encodeURIComponent(samlArtifact(partnerId, index))

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -30,7 +30,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
   app.get(`${PATH_PREFIX}/authorize`, (req, res) => {
     const redirectURI = req.query.redirect_uri
     const state = encodeURIComponent(req.query.state)
-    if (showLoginPage) {
+    if (showLoginPage(req)) {
       const oidc = assertions.oidc.singPass
       const values = oidc
         .filter((rawId) => assertions.myinfo.v3.personas[rawId])


### PR DESCRIPTION
## Problem

- Mockpass is very suitable as a mock Singpass server for writing E2E tests against, except for the HTML login page
- We can set the `SHOW_LOGIN_PAGE` environment variable to `false` to overcome this, but then it becomes less suitable for manual testing
- We then need to maintain two separate configurations / instances of Mockpass, one for automated E2E tests, and another for manual tests

## Solution

- Allow the `showLoginPage` config to be overridden per request via an `X-Show-Login-Page` HTTP header
- This way, E2E tests can send `X-Show-Login-Page: false` in the request, while manual testing can still be done in the browser, all against the same running instance of Mockpass