### PR TITLE
feat: allow custom identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ $ export CORPPASS_ASSERT_ENDPOINT=http://localhost:5000/corppass/assert
 # All values shown here are defaults
 $ export MOCKPASS_PORT=5156
 $ export MOCKPASS_NRIC=S8979373D
-$ export MOCKPASS_UEN=123456789A
 
 $ export SHOW_LOGIN_PAGE=true # Optional, defaults to `false`; can be overridden per request using `X-Show-Login-Page` HTTP header
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ $ export CORPPASS_ASSERT_ENDPOINT=http://localhost:5000/corppass/assert
 
 # All values shown here are defaults
 $ export MOCKPASS_PORT=5156
-$ export MOCKPASS_NRIC=S8979373D
 
 $ export SHOW_LOGIN_PAGE=true # Optional, defaults to `false`; can be overridden per request using `X-Show-Login-Page` HTTP header
+
+# Configure which profile to return when login page is disabled
+# Can be overridden per request using `X-Custom-NRIC`/`X-Custom-UUID`/`X-Custom-UEN` HTTP headers
+$ export MOCKPASS_NRIC=S8979373D # Optional, defaults to first profile
 
 # Disable signing/encryption (Optional, by default `true`)
 $ export SIGN_ASSERTION=false

--- a/index.js
+++ b/index.js
@@ -61,9 +61,8 @@ const options = {
       assertEndpoint: process.env.CORPPASS_ASSERT_ENDPOINT,
     },
   },
-  showLoginPage: (req) => {
-    return process.env.SHOW_LOGIN_PAGE === 'true' || req.header('X-Show-Login-Page') === 'true'
-  },
+  showLoginPage: (req) =>
+    (req.header('X-Show-Login-Page') || process.env.SHOW_LOGIN_PAGE) === 'true',
   encryptMyInfo: process.env.ENCRYPT_MYINFO === 'true',
   cryptoConfig,
 }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -307,13 +307,10 @@ const oidc = {
 
 const singPassNric = process.env.MOCKPASS_NRIC || saml.singPass[0]
 const corpPassNric = process.env.MOCKPASS_NRIC || saml.corpPass[0].nric
-const uen = process.env.MOCKPASS_UEN || saml.corpPass[0].uen
-
 module.exports = {
   saml,
   oidc,
   myinfo,
   singPassNric,
   corpPassNric,
-  uen,
 }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -19,17 +19,6 @@ const signingPem = fs.readFileSync(
   path.resolve(__dirname, '../static/certs/spcp-key.pem'),
 )
 
-const createRefreshToken = (uuid) => {
-  const prefixSize = (`${uuid}`.length + 1) / 2
-  const padding = Number.isInteger(prefixSize) ? '/' : '/f'
-
-  return (
-    uuid +
-    padding +
-    crypto.randomBytes(20 - Math.floor(prefixSize)).toString('hex')
-  )
-}
-
 const hashToken = (token) => {
   const fullHash = crypto.createHash('sha256')
   fullHash.update(token, 'utf8')
@@ -38,8 +27,8 @@ const hashToken = (token) => {
   if (Buffer.isEncoding('base64url')) {
     return digestBuffer.toString('base64url')
   } else {
-    const fromBase64 = (base64) =>
-      base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+    const fromBase64 = (base64String) =>
+      base64String.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
     return fromBase64(digestBuffer.toString('base64'))
   }
 }
@@ -51,42 +40,42 @@ const myinfo = {
 
 const saml = {
   singPass: [
-    'S8979373D',
-    'S8116474F',
-    'S8723211E',
-    'S5062854Z',
-    'T0066846F',
-    'F9477325W',
-    'S3000024B',
-    'S6005040F',
-    'S6005041D',
-    'S6005042B',
-    'S6005043J',
-    'S6005044I',
-    'S6005045G',
-    'S6005046E',
-    'S6005047C',
-    'S6005064C',
-    'S6005065A',
-    'S6005066Z',
-    'S6005037F',
-    'S6005038D',
-    'S6005039B',
-    'G1612357P',
-    'G1612358M',
-    'F1612359P',
-    'F1612360U',
-    'F1612361R',
-    'F1612362P',
-    'F1612363M',
-    'F1612364K',
-    'F1612365W',
-    'F1612366T',
-    'F1612367Q',
-    'F1612358R',
-    'F1612354N',
-    'F1612357U',
-    ...Object.keys(myinfo.v2.personas),
+    { nric: 'S8979373D' },
+    { nric: 'S8116474F' },
+    { nric: 'S8723211E' },
+    { nric: 'S5062854Z' },
+    { nric: 'T0066846F' },
+    { nric: 'F9477325W' },
+    { nric: 'S3000024B' },
+    { nric: 'S6005040F' },
+    { nric: 'S6005041D' },
+    { nric: 'S6005042B' },
+    { nric: 'S6005043J' },
+    { nric: 'S6005044I' },
+    { nric: 'S6005045G' },
+    { nric: 'S6005046E' },
+    { nric: 'S6005047C' },
+    { nric: 'S6005064C' },
+    { nric: 'S6005065A' },
+    { nric: 'S6005066Z' },
+    { nric: 'S6005037F' },
+    { nric: 'S6005038D' },
+    { nric: 'S6005039B' },
+    { nric: 'G1612357P' },
+    { nric: 'G1612358M' },
+    { nric: 'F1612359P' },
+    { nric: 'F1612360U' },
+    { nric: 'F1612361R' },
+    { nric: 'F1612362P' },
+    { nric: 'F1612363M' },
+    { nric: 'F1612364K' },
+    { nric: 'F1612365W' },
+    { nric: 'F1612366T' },
+    { nric: 'F1612367Q' },
+    { nric: 'F1612358R' },
+    { nric: 'F1612354N' },
+    { nric: 'F1612357U' },
+    ...Object.keys(myinfo.v2.personas).map((nric) => ({ nric })),
   ],
   corpPass: [
     { nric: 'S8979373D', uen: '123456789A' },
@@ -100,7 +89,7 @@ const saml = {
   ],
   create: {
     singPass: (
-      nric,
+      { nric },
       issuer,
       recipient,
       inResponseTo,
@@ -116,7 +105,7 @@ const saml = {
         audience,
       }),
     corpPass: (
-      source,
+      { nric, uen },
       issuer,
       recipient,
       inResponseTo,
@@ -124,8 +113,8 @@ const saml = {
     ) =>
       render(TEMPLATE, {
         issueInstant: moment.utc().format(),
-        name: source.uen,
-        value: base64.encode(render(corpPassTemplate, source)),
+        name: uen,
+        value: base64.encode(render(corpPassTemplate, { nric, uen })),
         recipient,
         issuer,
         inResponseTo,
@@ -136,88 +125,99 @@ const saml = {
 
 const oidc = {
   singPass: [
-    'S8979373D',
-    'S8116474F',
-    'S8723211E',
-    'S5062854Z',
-    'T0066846F',
-    'F9477325W',
-    'S3000024B',
-    'S6005040F',
-    'S6005041D',
-    'S6005042B',
-    'S6005043J',
-    'S6005044I',
-    'S6005045G',
-    'S6005046E',
-    'S6005047C',
-    'S6005064C',
-    'S6005065A',
-    'S6005066Z',
-    'S6005037F',
-    'S6005038D',
-    'S6005039B',
-    'G1612357P',
-    'G1612358M',
-    'F1612359P',
-    'F1612360U',
-    'F1612361R',
-    'F1612362P',
-    'F1612363M',
-    'F1612364K',
-    'F1612365W',
-    'F1612366T',
-    'F1612367Q',
-    'F1612358R',
-    'F1612354N',
-    'F1612357U',
-    ...Object.keys(myinfo.v3.personas),
+    { nric: 'S8979373D', uuid: 'a9865837-7bd7-46ac-bef4-42a76a946424' },
+    { nric: 'S8116474F', uuid: 'f4b70aea-d639-4b79-b8d9-8ace5875f6b1' },
+    { nric: 'S8723211E', uuid: '178478de-fed7-4c03-a75e-e68c44d0d5f0' },
+    { nric: 'S5062854Z', uuid: '1bd2e743-8681-4079-a557-6a66a8d16386' },
+    { nric: 'T0066846F', uuid: '14f7ee8f-9e64-4170-a529-e55ca7578e2b' },
+    { nric: 'F9477325W', uuid: '2135fe5c-d07b-49d3-b960-aabb0ff2e05a' },
+    { nric: 'S3000024B', uuid: 'b5630beb-e3ee-4a31-aec5-534cdc087fd8' },
+    { nric: 'S6005040F', uuid: '6c6745d9-e6c5-40ee-8c96-5d737ddbc5e4' },
+    { nric: 'S6005041D', uuid: 'bd3fd1e0-c807-4b07-bbe4-b567cab54b8c' },
+    { nric: 'S6005042B', uuid: '2dd788c0-d11f-4d5b-99af-b89d2389b474' },
+    { nric: 'S6005043J', uuid: 'eb196477-36b3-4c0f-ae5e-2172e2f6a6d8' },
+    { nric: 'S6005044I', uuid: '843ebc6b-1de1-4d46-b1dd-9ad4aeac3a27' },
+    { nric: 'S6005045G', uuid: 'caafaedc-f369-498a-9e35-27e9cb7f0de2' },
+    { nric: 'S6005046E', uuid: 'f9b37d06-de3f-4c4f-8331-37a3b2ee6cb4' },
+    { nric: 'S6005047C', uuid: '57620e0f-fdf9-4f3e-a8f6-f6088e151395' },
+    { nric: 'S6005064C', uuid: '80952b2f-3455-4b59-b50f-39afbc418271' },
+    { nric: 'S6005065A', uuid: '3af48e26-69a1-43e3-b5f2-303098ef3210' },
+    { nric: 'S6005066Z', uuid: '8b2f8213-2fe9-493a-ac95-0b55e319e689' },
+    { nric: 'S6005037F', uuid: 'ae3d1d8c-6d14-449e-8ed1-9ce3d5e67607' },
+    { nric: 'S6005038D', uuid: '23d3bb45-a324-46d6-b0d9-2e94194ed9ae' },
+    { nric: 'S6005039B', uuid: '9ac807a2-5217-417a-a8d1-d7018b002b3f' },
+    { nric: 'G1612357P', uuid: 'eb125a02-3137-486f-9262-eab3e0c57a5f' },
+    { nric: 'G1612358M', uuid: 'd821900c-663d-4552-a753-a2e1cf8d124f' },
+    { nric: 'F1612359P', uuid: '08df8d35-600c-45fd-a812-b37a27b7856a' },
+    { nric: 'F1612360U', uuid: '1e90b698-23af-4acb-9fb4-eb5a80f444b6' },
+    { nric: 'F1612361R', uuid: 'bc134ee1-f104-4b26-9839-32047fecb963' },
+    { nric: 'F1612362P', uuid: '285e8366-f3bd-48b4-8153-b47260fc9f56' },
+    { nric: 'F1612363M', uuid: '379bc106-d3db-492c-a38e-fd27642ef47f' },
+    { nric: 'F1612364K', uuid: '108fa3ff-c85c-461e-ba1f-8edef62b68e2' },
+    { nric: 'F1612365W', uuid: '1275ae4e-02d2-4b09-9573-36ac610ede89' },
+    { nric: 'F1612366T', uuid: '23c6a3a4-d9d8-445f-a588-9d91831980a6' },
+    { nric: 'F1612367Q', uuid: '0c400961-eb00-425a-8df4-6656b0b9245a' },
+    { nric: 'F1612358R', uuid: '45669f5c-e9ac-43c6-bcd2-9c3757f1fa1c' },
+    { nric: 'F1612354N', uuid: 'c38ddb2d-9e5d-45c2-bb70-8ccb54fc8320' },
+    { nric: 'F1612357U', uuid: 'f904a2b1-4b61-47e2-bdad-e2d606325e20' },
+    ...Object.keys(myinfo.v3.personas).map((nric) => ({
+      nric,
+      uuid: myinfo.v3.personas[nric].uuid.value,
+    })),
   ],
   corpPass: [
     {
       nric: 'S8979373D',
+      uuid: 'a9865837-7bd7-46ac-bef4-42a76a946424',
       name: 'Name of S8979373D',
       isSingPassHolder: true,
       uen: '123456789A',
     },
     {
       nric: 'S8116474F',
+      uuid: 'f4b70aea-d639-4b79-b8d9-8ace5875f6b1',
       name: 'Name of S8116474F',
       isSingPassHolder: true,
       uen: '123456789A',
     },
     {
       nric: 'S8723211E',
+      uuid: '178478de-fed7-4c03-a75e-e68c44d0d5f0',
       name: 'Name of S8723211E',
       isSingPassHolder: true,
       uen: '123456789A',
     },
     {
       nric: 'S5062854Z',
+      uuid: '1bd2e743-8681-4079-a557-6a66a8d16386',
       name: 'Name of S5062854Z',
       isSingPassHolder: true,
       uen: '123456789B',
     },
     {
       nric: 'T0066846F',
+      uuid: '14f7ee8f-9e64-4170-a529-e55ca7578e2b',
       name: 'Name of T0066846F',
       isSingPassHolder: true,
       uen: '123456789B',
     },
     {
       nric: 'F9477325W',
+      uuid: '2135fe5c-d07b-49d3-b960-aabb0ff2e05a',
       name: 'Name of F9477325W',
       isSingPassHolder: false,
       uen: '123456789B',
     },
     {
       nric: 'S3000024B',
+      uuid: 'b5630beb-e3ee-4a31-aec5-534cdc087fd8',
       name: 'Name of S3000024B',
       isSingPassHolder: true,
       uen: '123456789C',
     },
     {
       nric: 'S6005040F',
+      uuid: '6c6745d9-e6c5-40ee-8c96-5d737ddbc5e4',
       name: 'Name of S6005040F',
       isSingPassHolder: true,
       uen: '123456789C',
@@ -225,17 +225,17 @@ const oidc = {
   ],
   create: {
     singPass: (
-      uuid,
+      { nric, uuid },
       iss,
       aud,
       nonce,
       accessToken = crypto.randomBytes(15).toString('hex'),
     ) => {
-      const nric = oidc.singPass[uuid]
       const sub = `s=${nric},u=${uuid}`
 
-      const refreshToken = createRefreshToken(uuid)
       const accessTokenHash = hashToken(accessToken)
+
+      const refreshToken = crypto.randomBytes(20).toString('hex')
       const refreshTokenHash = hashToken(refreshToken)
 
       return {
@@ -254,7 +254,12 @@ const oidc = {
         },
       }
     },
-    corpPass: async (uuid, iss, aud, nonce) => {
+    corpPass: async (
+      { nric, uuid, name, isSingPassHolder },
+      iss,
+      aud,
+      nonce,
+    ) => {
       const baseClaims = {
         iat: Math.floor(Date.now() / 1000),
         exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
@@ -262,8 +267,7 @@ const oidc = {
         aud,
       }
 
-      const profile = oidc.corpPass[uuid]
-      const sub = `s=${profile.nric},u=${uuid},c=SG`
+      const sub = `s=${nric},u=${uuid},c=SG`
 
       const accessTokenClaims = {
         ...baseClaims,
@@ -284,20 +288,23 @@ const oidc = {
 
       const accessTokenHash = hashToken(accessToken)
 
+      const refreshToken = crypto.randomBytes(20).toString('hex')
+      const refreshTokenHash = hashToken(refreshToken)
+
       return {
-        refreshToken: 'refresh',
         accessToken,
+        refreshToken,
         idTokenClaims: {
           ...baseClaims,
-          rt_hash: '',
+          rt_hash: refreshTokenHash,
           at_hash: accessTokenHash,
           amr: ['pwd'],
           sub,
           ...(nonce ? { nonce } : {}),
           userInfo: {
             CPAccType: 'User',
-            CPUID_FullName: profile.name,
-            ISSPHOLDER: profile.isSingPassHolder ? 'YES' : 'NO',
+            CPUID_FullName: name,
+            ISSPHOLDER: isSingPassHolder ? 'YES' : 'NO',
           },
         },
       }
@@ -305,12 +312,8 @@ const oidc = {
   },
 }
 
-const singPassNric = process.env.MOCKPASS_NRIC || saml.singPass[0]
-const corpPassNric = process.env.MOCKPASS_NRIC || saml.corpPass[0].nric
 module.exports = {
   saml,
   oidc,
   myinfo,
-  singPassNric,
-  corpPassNric,
 }

--- a/lib/auth-code.js
+++ b/lib/auth-code.js
@@ -1,0 +1,17 @@
+const ExpiryMap = require('expiry-map')
+const crypto = require('crypto')
+
+const AUTH_CODE_TIMEOUT = 5 * 60 * 1000
+const profileAndNonceStore = new ExpiryMap(AUTH_CODE_TIMEOUT)
+
+const generateAuthCode = ({ profile, nonce }) => {
+  const authCode = crypto.randomBytes(45).toString('base64')
+  profileAndNonceStore.set(authCode, { profile, nonce })
+  return authCode
+}
+
+const lookUpByAuthCode = (authCode) => {
+  return profileAndNonceStore.get(authCode)
+}
+
+module.exports = { generateAuthCode, lookUpByAuthCode }

--- a/lib/express/myinfo/consent.js
+++ b/lib/express/myinfo/consent.js
@@ -8,6 +8,8 @@ const qs = require('querystring')
 const { v1: uuid } = require('uuid')
 
 const assertions = require('../../assertions')
+const { lookUpByAuthCode } = require('../../auth-code')
+const { lookUpBySamlArtifact } = require('../../saml-artifact')
 
 const MYINFO_ASSERT_ENDPOINT = '/consent/myinfo-com'
 const AUTHORIZE_ENDPOINT = '/consent/oauth2/authorize'
@@ -47,41 +49,33 @@ const authorizeViaSAML = authorize(
 )
 
 const authorizeViaOIDC = authorize(
-  (relayState) =>
-    `/singpass/authorize?client_id=MYINFO-CONSENTPLATFORM&redirect_uri=${MYINFO_ASSERT_ENDPOINT}&state=${relayState}`,
+  (state) =>
+    `/singpass/authorize?client_id=MYINFO-CONSENTPLATFORM&redirect_uri=${MYINFO_ASSERT_ENDPOINT}&state=${state}`,
 )
 
 function config(app) {
   app.get(MYINFO_ASSERT_ENDPOINT, (req, res) => {
     const rawArtifact = req.query.SAMLart || req.query.code
     const artifact = rawArtifact.replace(/ /g, '+')
-    const artifactBuffer = Buffer.from(artifact, 'base64')
-    const artifactMessage = artifactBuffer.toString('utf8', 24)
-    let index = artifactBuffer.readInt8(artifactBuffer.length - 1)
-
     const state = req.query.RelayState || req.query.state
-    let id
-    if (artifactMessage.startsWith('customNric:')) {
-      id = artifactMessage.slice('customNric:'.length)
-    } else {
-      const assertionType = req.query.code ? 'oidc' : 'saml'
 
-      // use env NRIC when SHOW_LOGIN_PAGE is false
-      if (index === -1) {
-        index = assertions[assertionType].singPass.indexOf(
-          assertions.singPassNric,
-        )
-      }
-      id = assertions[assertionType].singPass[index]
+    let profile, myinfoVersion
+    if (req.query.code) {
+      profile = lookUpByAuthCode(artifact).profile
+      myinfoVersion = 'v3'
+    } else {
+      profile = lookUpBySamlArtifact(artifact)
+      myinfoVersion = 'v2'
     }
-    const persona = assertions.myinfo[req.query.code ? 'v3' : 'v2'].personas[id]
+    const { nric: id } = profile
+
+    const persona = assertions.myinfo[myinfoVersion].personas[id]
     if (!persona) {
       res.status(404).send({
         message: 'Cannot find MyInfo Persona',
         artifact,
-        index,
+        myinfoVersion,
         id,
-        persona,
       })
     } else {
       res.cookie('connect.sid', id)

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -69,7 +69,17 @@ function config(app, { showLoginPage, serviceProvider }) {
           const id = idGenerator[idp](profile)
           return { id, assertURL }
         })
-        const response = render(LOGIN_TEMPLATE, { values })
+        const response = render(LOGIN_TEMPLATE, {
+          values,
+          customProfileConfig: {
+            endpoint: `/${idp.toLowerCase()}/authorize/custom-profile`,
+            showUuid: true,
+            showUen: idp === 'corpPass',
+            redirectURI,
+            state,
+            nonce,
+          },
+        })
         res.send(response)
       } else {
         const profile = customProfileFromHeaders[idp](req) || defaultProfile
@@ -80,6 +90,21 @@ function config(app, { showLoginPage, serviceProvider }) {
         )
         res.redirect(assertURL)
       }
+    })
+
+    app.get(`/${idp.toLowerCase()}/authorize/custom-profile`, (req, res) => {
+      const { nric, uuid, uen, redirectURI, state, nonce } = req.query
+
+      const profile = { nric, uuid }
+      if (idp === 'corpPass') {
+        profile.name = `Name of ${nric}`
+        profile.isSingPassHolder = false
+        profile.uen = uen
+      }
+
+      const authCode = generateAuthCode({ profile, nonce })
+      const assertURL = buildAssertURL(redirectURI, authCode, state)
+      res.redirect(assertURL)
     })
 
     app.post(

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -6,51 +6,75 @@ const path = require('path')
 const ExpiryMap = require('expiry-map')
 
 const assertions = require('../assertions')
-const { samlArtifact } = require('../saml-artifact')
+const { generateAuthCode, lookUpByAuthCode } = require('../auth-code')
 
 const LOGIN_TEMPLATE = fs.readFileSync(
   path.resolve(__dirname, '../../static/html/login-page.html'),
   'utf8',
 )
-const NONCE_TIMEOUT = 5 * 60 * 1000
-const nonceStore = new ExpiryMap(NONCE_TIMEOUT)
+const REFRESH_TOKEN_TIMEOUT = 24 * 60 * 60 * 1000
+const profileStore = new ExpiryMap(REFRESH_TOKEN_TIMEOUT)
 
 const signingPem = fs.readFileSync(
   path.resolve(__dirname, '../../static/certs/spcp-key.pem'),
 )
 
+const buildAssertURL = (redirectURI, authCode, state) =>
+  `${redirectURI}?code=${encodeURIComponent(
+    authCode,
+  )}&state=${encodeURIComponent(state)}`
+
 const idGenerator = {
-  singPass: (rawId) =>
-    assertions.myinfo.v3.personas[rawId] ? `${rawId} [MyInfo]` : rawId,
-  corpPass: (rawId) => `${rawId.nric} / UEN: ${rawId.uen}`,
+  singPass: ({ nric }) =>
+    assertions.myinfo.v3.personas[nric] ? `${nric} [MyInfo]` : nric,
+  corpPass: ({ nric, uen }) => `${nric} / UEN: ${uen}`,
 }
 
-function config(app, { showLoginPage, idpConfig, serviceProvider }) {
+const customProfileFromHeaders = {
+  singPass: (req) => {
+    const customNricHeader = req.header('X-Custom-NRIC')
+    const customUuidHeader = req.header('X-Custom-UUID')
+    if (!customNricHeader || !customUuidHeader) {
+      return false
+    }
+    return { nric: customNricHeader, uuid: customUuidHeader }
+  },
+  corpPass: (req) => {
+    const customNricHeader = req.header('X-Custom-NRIC')
+    const customUuidHeader = req.header('X-Custom-UUID')
+    const customUenHeader = req.header('X-Custom-UEN')
+    if (!customNricHeader || !customUuidHeader || !customUenHeader) {
+      return false
+    }
+    return {
+      nric: customNricHeader,
+      uuid: customUuidHeader,
+      uen: customUenHeader,
+    }
+  },
+}
+
+function config(app, { showLoginPage, serviceProvider }) {
   for (const idp of ['singPass', 'corpPass']) {
+    const profiles = assertions.oidc[idp]
+    const defaultProfile =
+      profiles.find((p) => p.nric === process.env.MOCKPASS_NRIC) || profiles[0]
+
     app.get(`/${idp.toLowerCase()}/authorize`, (req, res) => {
-      const redirectURI = req.query.redirect_uri
-      const state = encodeURIComponent(req.query.state)
+      const { redirect_uri: redirectURI, state, nonce } = req.query
       if (showLoginPage(req)) {
-        const oidc = assertions.oidc[idp]
-        const values = oidc.map((rawId, index) => {
-          const code = encodeURIComponent(
-            samlArtifact(idpConfig[idp].id, index),
-          )
-          if (req.query.nonce) {
-            nonceStore.set(code, req.query.nonce)
-          }
-          const assertURL = `${redirectURI}?code=${code}&state=${state}`
-          const id = idGenerator[idp](rawId)
+        const values = profiles.map((profile) => {
+          const authCode = generateAuthCode({ profile, nonce })
+          const assertURL = buildAssertURL(redirectURI, authCode, state)
+          const id = idGenerator[idp](profile)
           return { id, assertURL }
         })
         const response = render(LOGIN_TEMPLATE, { values })
         res.send(response)
       } else {
-        const code = encodeURIComponent(samlArtifact(idpConfig[idp].id))
-        if (req.query.nonce) {
-          nonceStore.set(code, req.query.nonce)
-        }
-        const assertURL = `${redirectURI}?code=${code}&state=${state}`
+        const profile = customProfileFromHeaders[idp](req) || defaultProfile
+        const authCode = generateAuthCode({ profile, nonce })
+        const assertURL = buildAssertURL(redirectURI, authCode, state)
         console.warn(
           `Redirecting login from ${req.query.client_id} to ${redirectURI}`,
         )
@@ -63,40 +87,27 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       express.urlencoded({ extended: false }),
       async (req, res) => {
         const { client_id: aud, grant_type: grant } = req.body
-        let nonce, uuid
+        let profile, nonce
 
         if (grant === 'refresh_token') {
-          const { refresh_token: refreshToken } = req.body
-          console.warn(`Refreshing tokens with ${refreshToken}`)
+          const { refresh_token: suppliedRefreshToken } = req.body
+          console.warn(`Refreshing tokens with ${suppliedRefreshToken}`)
 
-          uuid = refreshToken.split('/')[0]
+          profile = profileStore.get(suppliedRefreshToken)
         } else {
-          const { code: artifact } = req.body
+          const { code: authCode } = req.body
           console.warn(
-            `Received artifact ${artifact} from ${aud} and ${req.body.redirect_uri}`,
+            `Received auth code ${authCode} from ${aud} and ${req.body.redirect_uri}`,
           )
-          const artifactBuffer = Buffer.from(artifact, 'base64')
-          uuid = artifactBuffer.readInt8(artifactBuffer.length - 1)
-          nonce = nonceStore.get(encodeURIComponent(artifact))
+          ;({ profile, nonce } = lookUpByAuthCode(authCode))
         }
 
-        // use env NRIC when SHOW_LOGIN_PAGE is false
-        if (uuid === -1) {
-          uuid =
-            idp === 'singPass'
-              ? assertions.oidc.singPass.indexOf(assertions.singPassNric)
-              : assertions.oidc.corpPass.findIndex(
-                  (c) => c.nric === assertions.corpPassNric,
-                )
-        }
+        const iss = `${req.protocol}://${req.get('host')}`
 
         const { idTokenClaims, accessToken, refreshToken } =
-          await assertions.oidc.create[idp](
-            uuid,
-            `${req.protocol}://${req.get('host')}`,
-            aud,
-            nonce,
-          )
+          await assertions.oidc.create[idp](profile, iss, aud, nonce)
+
+        profileStore.set(refreshToken, profile)
 
         const signingKey = await jose.JWK.asKey(signingPem, 'pem')
         const signedIdToken = await jose.JWS.createSign(

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -87,12 +87,15 @@ function config(
           const id = idGenerator[idp](profile)
           return { id, assertURL }
         })
-        const hashedPartnerId = hashPartnerId(partnerId)
         const response = render(LOGIN_TEMPLATE, {
           values,
-          assertEndpoint,
-          relayState,
-          hashedPartnerId,
+          customProfileConfig: {
+            endpoint: `/${idp.toLowerCase()}/logininitial/custom-profile`,
+            showUuid: false,
+            showUen: idp === 'corpPass',
+            assertEndpoint,
+            relayState,
+          },
         })
         res.send(response)
       } else {
@@ -104,6 +107,19 @@ function config(
         )
         res.redirect(assertURL)
       }
+    })
+
+    app.get(`/${idp.toLowerCase()}/logininitial/custom-profile`, (req, res) => {
+      const { nric, uen, assertEndpoint, relayState } = req.query
+
+      const profile = { nric }
+      if (idp === 'corpPass') {
+        profile.uen = uen
+      }
+
+      const samlArt = generateSamlArtifact(partnerId, profile)
+      const assertURL = buildAssertURL(assertEndpoint, samlArt, relayState)
+      res.redirect(assertURL)
     })
 
     app.post(

--- a/lib/express/saml.js
+++ b/lib/express/saml.js
@@ -8,7 +8,10 @@ const moment = require('moment')
 
 const assertions = require('../assertions')
 const crypto = require('../crypto')
-const { samlArtifact, hashPartnerId } = require('../saml-artifact')
+const {
+  generateSamlArtifact,
+  lookUpBySamlArtifact,
+} = require('../saml-artifact')
 
 const domParser = new DOMParser()
 const dom = (xmlString) => domParser.parseFromString(xmlString)
@@ -24,10 +27,36 @@ const LOGIN_TEMPLATE = fs.readFileSync(
 
 const MYINFO_ASSERT_ENDPOINT = '/consent/myinfo-com'
 
+const buildAssertURL = (assertEndpoint, samlArt, relayState) => {
+  let assertURL = `${assertEndpoint}?SAMLart=${encodeURIComponent(samlArt)}`
+  if (relayState !== undefined) {
+    assertURL += `&RelayState=${encodeURIComponent(relayState)}`
+  }
+  return assertURL
+}
+
 const idGenerator = {
-  singPass: (rawId) =>
-    assertions.myinfo.v2.personas[rawId] ? `${rawId} [MyInfo]` : rawId,
-  corpPass: (rawId) => `${rawId.nric} / UEN: ${rawId.uen}`,
+  singPass: ({ nric }) =>
+    assertions.myinfo.v2.personas[nric] ? `${nric} [MyInfo]` : nric,
+  corpPass: ({ nric, uen }) => `${nric} / UEN: ${uen}`,
+}
+
+const customProfileFromHeaders = {
+  singPass: (req) => {
+    const customNricHeader = req.header('X-Custom-NRIC')
+    if (!customNricHeader) {
+      return false
+    }
+    return { nric: customNricHeader }
+  },
+  corpPass: (req) => {
+    const customNricHeader = req.header('X-Custom-NRIC')
+    const customUenHeader = req.header('X-Custom-UEN')
+    if (!customNricHeader || !customUenHeader) {
+      return false
+    }
+    return { nric: customNricHeader, uen: customUenHeader }
+  },
 }
 
 function config(
@@ -38,22 +67,24 @@ function config(
     crypto(serviceProvider)
 
   for (const idp of ['singPass', 'corpPass']) {
+    const partnerId = idpConfig[idp].id
+    const partnerAssertEndpoint = idpConfig[idp].assertEndpoint
+
+    const profiles = assertions.saml[idp]
+    const defaultProfile =
+      profiles.find((p) => p.nric === process.env.MOCKPASS_NRIC) || profiles[0]
+
     app.get(`/${idp.toLowerCase()}/logininitial`, (req, res) => {
       const assertEndpoint =
         req.query.esrvcID === 'MYINFO-CONSENTPLATFORM' && idp === 'singPass'
           ? MYINFO_ASSERT_ENDPOINT
-          : idpConfig[idp].assertEndpoint || req.query.PartnerId
+          : partnerAssertEndpoint || req.query.PartnerId
       const relayState = req.query.Target
-      const partnerId = idpConfig[idp].id
       if (showLoginPage(req)) {
-        const saml = assertions.saml[idp]
-        const values = saml.map((rawId, index) => {
-          const samlArt = encodeURIComponent(samlArtifact(partnerId, index))
-          let assertURL = `${assertEndpoint}?SAMLart=${samlArt}`
-          if (relayState !== undefined) {
-            assertURL += `&RelayState=${encodeURIComponent(relayState)}`
-          }
-          const id = idGenerator[idp](rawId)
+        const values = profiles.map((profile) => {
+          const samlArt = generateSamlArtifact(partnerId, profile)
+          const assertURL = buildAssertURL(assertEndpoint, samlArt, relayState)
+          const id = idGenerator[idp](profile)
           return { id, assertURL }
         })
         const hashedPartnerId = hashPartnerId(partnerId)
@@ -65,11 +96,9 @@ function config(
         })
         res.send(response)
       } else {
-        const samlArt = encodeURIComponent(samlArtifact(partnerId))
-        let assertURL = `${assertEndpoint}?SAMLart=${samlArt}`
-        if (relayState !== undefined) {
-          assertURL += `&RelayState=${encodeURIComponent(relayState)}`
-        }
+        const profile = customProfileFromHeaders[idp](req) || defaultProfile
+        const samlArt = generateSamlArtifact(partnerId, profile)
+        const assertURL = buildAssertURL(assertEndpoint, samlArt, relayState)
         console.warn(
           `Redirecting login from ${req.query.PartnerId} to ${assertURL}`,
         )
@@ -102,28 +131,7 @@ function config(
           // Handle encoded base64 Artifact
           // Take the template and plug in the typical SingPass/CorpPass response
           // Sign and encrypt the assertion
-          const samlArtifactBuffer = Buffer.from(samlArtifact, 'base64')
-          const samlArtifactMessage = samlArtifactBuffer.toString('utf8', 24)
-
-          let nric
-          if (samlArtifactMessage.startsWith('customNric:')) {
-            nric = samlArtifactMessage.slice('customNric:'.length)
-          } else {
-            let index = samlArtifactBuffer.readInt8(
-              samlArtifactBuffer.length - 1,
-            )
-            // use env NRIC when SHOW_LOGIN_PAGE is false
-            if (index === -1) {
-              index =
-                idp === 'singPass'
-                  ? assertions.saml.singPass.indexOf(assertions.singPassNric)
-                  : assertions.saml.corpPass.findIndex(
-                      (c) => c.nric === assertions.corpPassNric,
-                    )
-            }
-
-            nric = assertions.saml[idp][index]
-          }
+          const profile = lookUpBySamlArtifact(samlArtifact)
 
           const samlArtifactResolveId = xpath.select(
             "string(//*[local-name(.)='ArtifactResolve']/@ID)",
@@ -131,9 +139,9 @@ function config(
           )
 
           let result = assertions.saml.create[idp](
-            nric,
-            idpConfig[idp].id,
-            idpConfig[idp].assertEndpoint,
+            profile,
+            partnerId,
+            partnerAssertEndpoint,
             samlArtifactResolveId,
           )
 
@@ -148,8 +156,8 @@ function config(
             let response = render(TEMPLATE, {
               assertion,
               issueInstant: moment.utc().format(),
-              issuer: idpConfig[idp].id,
-              destination: idpConfig[idp].assertEndpoint,
+              issuer: partnerId,
+              destination: partnerAssertEndpoint,
               inResponseTo: samlArtifactResolveId,
             })
             if (cryptoConfig.signResponse) {

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -3,17 +3,14 @@ const fs = require('fs')
 const { render } = require('mustache')
 const jose = require('node-jose')
 const path = require('path')
-const ExpiryMap = require('expiry-map')
 
 const assertions = require('../assertions')
-const { samlArtifact } = require('../saml-artifact')
+const { generateAuthCode, lookUpByAuthCode } = require('../auth-code')
 
 const LOGIN_TEMPLATE = fs.readFileSync(
   path.resolve(__dirname, '../../static/html/login-page.html'),
   'utf8',
 )
-const NONCE_TIMEOUT = 5 * 60 * 1000
-const nonceStore = new ExpiryMap(NONCE_TIMEOUT)
 
 const PATH_PREFIX = '/sgid/v1/oauth'
 
@@ -22,38 +19,37 @@ const signingPem = fs.readFileSync(
 )
 
 const idGenerator = {
-  singPass: (rawId) =>
-    assertions.myinfo.v3.personas[rawId] ? `${rawId} [MyInfo]` : rawId,
+  singPass: ({ nric }) =>
+    assertions.myinfo.v3.personas[nric] ? `${nric} [MyInfo]` : nric,
 }
 
-function config(app, { showLoginPage, idpConfig, serviceProvider }) {
+const buildAssertURL = (redirectURI, authCode, state) =>
+  `${redirectURI}?code=${encodeURIComponent(
+    authCode,
+  )}&state=${encodeURIComponent(state)}`
+
+function config(app, { showLoginPage, serviceProvider }) {
+  const profiles = assertions.oidc.singPass
+  const defaultProfile =
+    profiles.find((p) => p.nric === process.env.MOCKPASS_NRIC) || profiles[0]
+
   app.get(`${PATH_PREFIX}/authorize`, (req, res) => {
-    const redirectURI = req.query.redirect_uri
-    const state = encodeURIComponent(req.query.state)
+    const { redirect_uri: redirectURI, state, nonce } = req.query
     if (showLoginPage(req)) {
-      const oidc = assertions.oidc.singPass
-      const values = oidc
-        .filter((rawId) => assertions.myinfo.v3.personas[rawId])
-        .map((rawId) => {
-          const index = oidc.indexOf(rawId)
-          const code = encodeURIComponent(
-            samlArtifact(idpConfig.singPass.id, index),
-          )
-          if (req.query.nonce) {
-            nonceStore.set(code, req.query.nonce)
-          }
-          const assertURL = `${redirectURI}?code=${code}&state=${state}`
-          const id = idGenerator.singPass(rawId)
+      const values = profiles
+        .filter((profile) => assertions.myinfo.v3.personas[profile.nric])
+        .map((profile) => {
+          const authCode = generateAuthCode({ profile, nonce })
+          const assertURL = buildAssertURL(redirectURI, authCode, state)
+          const id = idGenerator.singPass(profile)
           return { id, assertURL }
         })
       const response = render(LOGIN_TEMPLATE, { values })
       res.send(response)
     } else {
-      const code = encodeURIComponent(samlArtifact(idpConfig.singPass.id))
-      if (req.query.nonce) {
-        nonceStore.set(code, req.query.nonce)
-      }
-      const assertURL = `${redirectURI}?code=${code}&state=${state}`
+      const profile = defaultProfile
+      const authCode = generateAuthCode({ profile, nonce })
+      const assertURL = buildAssertURL(redirectURI, authCode, state)
       console.warn(
         `Redirecting login from ${req.query.client_id} to ${assertURL}`,
       )
@@ -67,31 +63,24 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
     express.urlencoded({ extended: true }),
     async (req, res) => {
       console.log(req.body)
-      const { client_id: aud, code: artifact } = req.body
-      let uuid
+      const { client_id: aud, code: authCode } = req.body
 
       console.warn(
-        `Received artifact ${artifact} from ${aud} and ${req.body.redirect_uri}`,
+        `Received auth code ${authCode} from ${aud} and ${req.body.redirect_uri}`,
       )
       try {
-        const artifactBuffer = Buffer.from(artifact, 'base64')
-        uuid = artifactBuffer.readInt8(artifactBuffer.length - 1)
-        const nonce = nonceStore.get(encodeURIComponent(artifact))
+        const { profile, nonce } = lookUpByAuthCode(authCode)
 
-        // use env NRIC when SHOW_LOGIN_PAGE is false
-        if (uuid === -1) {
-          uuid = assertions.oidc.singPass.indexOf(assertions.singPassNric)
-        }
+        const accessToken = profile.uuid
+        const iss = `${req.protocol}://${req.get('host')}`
 
-        const accessToken = `${uuid}`
-        const { idTokenClaims, refreshToken } =
-          await assertions.oidc.create.singPass(
-            uuid,
-            `${req.protocol}://${req.get('host')}`,
-            aud,
-            nonce,
-            accessToken,
-          )
+        const { idTokenClaims, refreshToken } = assertions.oidc.create.singPass(
+          profile,
+          iss,
+          aud,
+          nonce,
+          accessToken,
+        )
         // Change sub from `s=${nric},u=${uuid}`
         // to `u=${uuid}` to be consistent with userinfo sub
         idTokenClaims.sub = idTokenClaims.sub.split(',')[1]
@@ -123,7 +112,7 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
     const uuid = (
       req.headers.authorization || req.headers.Authorization
     ).replace('Bearer ', '')
-    const nric = assertions.oidc.singPass[uuid]
+    const nric = assertions.oidc.singPass.find((p) => p.uuid === uuid).nric
     const persona = assertions.myinfo.v3.personas[nric]
     const name = persona.name.value
     const dateOfBirth = persona.dob.value

--- a/lib/saml-artifact.js
+++ b/lib/saml-artifact.js
@@ -1,4 +1,8 @@
+const ExpiryMap = require('expiry-map')
 const crypto = require('crypto')
+
+const SAML_ARTIFACT_TIMEOUT = 5 * 60 * 1000
+const profileStore = new ExpiryMap(SAML_ARTIFACT_TIMEOUT)
 
 /**
  * Construct a SingPass/CorpPass SAML artifact, a base64
@@ -8,25 +12,28 @@ const crypto = require('crypto')
  *  - a 20-byte sha1 hash of the partner id, and;
  *  - a 20-byte random sequence that is effectively the message id
  * @param {string} partnerId - the partner id
- * @param {number} [index] - represents the nth identity to use. Defaults to -1
+ * @param {string} profile - the profile (identity) to store
  * @return {string} the SAML artifact, a base64 string
  * containing the type code, the endpoint index,
- * the hash of the partner id, followed by 20 random bytes
+ * the hash of the partner id, followed by 20 random bytes;
+ * this can be used to look up the stored profile (identity)
  */
-function samlArtifact(partnerId, index) {
-  const hashedPartnerId = hashPartnerId(partnerId)
-  const randomBytes = crypto.randomBytes(19).toString('hex')
-  const indexBuffer = Buffer.alloc(1)
-  indexBuffer.writeInt8(index || index === 0 ? index : -1)
-  const indexString = indexBuffer.toString('hex')
-  return Buffer.from(
-    `00040000${hashedPartnerId}${randomBytes}${indexString}`,
+function generateSamlArtifact(partnerId, profile) {
+  const hashedPartnerId = crypto
+    .createHash('sha1')
+    .update(partnerId, 'utf8')
+    .digest('hex')
+  const randomBytes = crypto.randomBytes(20).toString('hex')
+  const samlArtifact = Buffer.from(
+    `00040000${hashedPartnerId}${randomBytes}`,
     'hex',
   ).toString('base64')
+  profileStore.set(samlArtifact, profile)
+  return samlArtifact
 }
 
-function hashPartnerId(partnerId) {
-  return crypto.createHash('sha1').update(partnerId, 'utf8').digest('hex')
+function lookUpBySamlArtifact(samlArtifact) {
+  return profileStore.get(samlArtifact)
 }
 
-module.exports = { samlArtifact, hashPartnerId }
+module.exports = { generateSamlArtifact, lookUpBySamlArtifact }

--- a/public/mockpass/resources/js/login-common.js
+++ b/public/mockpass/resources/js/login-common.js
@@ -768,31 +768,6 @@ function invalidLoginAction(errorMessage, captchaVal) {
     }
 }
 
-function hexEncode(str) {
-    var result = '';
-    for (var i = 0; i < str.length; i++) {
-        result += str.charCodeAt(i).toString(16);
-    }
-    return result;
-}
-
-function hexToBase64(hexString) {
-    return btoa(hexString.match(/\w{2}/g).map(function(a) {
-        return String.fromCharCode(parseInt(a, 16));
-    }).join(''));
-}
-
-function generateSamlArtFromCustomNric() {
-    var customNric = document.getElementById('customNric').value;
-    if (customNric.length !== 9) {
-        return false;
-    }
-    var hashedPartnerId = document.getElementById('hashedPartnerId').value;
-    var artifactDataHex = '00040000' + hashedPartnerId + hexEncode('customNric:' + customNric);
-    document.getElementById('customNricSamlArt').value = hexToBase64(artifactDataHex);
-    return true;
-}
-
 /*******************************************************************************
  * WOGAA RELATED METHODS STARTS
  ******************************************************************************/

--- a/static/html/login-page.html
+++ b/static/html/login-page.html
@@ -176,33 +176,38 @@
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    <div>
-
-                                                    <input type="hidden" name="CSRFToken" value="null" />
-                                                    </div>
+                                                        <div>
+                                                            <input type="hidden" name="CSRFToken" value="null" />
+                                                        </div>
                                                     </form>
-                                                    <form action="{{assertEndpoint}}" method="get" onsubmit="return generateSamlArtFromCustomNric()">
+                                                    {{#customProfileConfig}}
+                                                    <form action="{{endpoint}}" class="innate-form" method="get">
                                                         <br>
-                                                        {{#assertEndpoint}}
-                                                            <h6>or with your own user</h6>
-                                                            <br>
-                                                            <input type="hidden" name="RelayState" value="{{ relayState }}" />
-                                                            <input type="hidden" id="hashedPartnerId" value="{{ hashedPartnerId }}" />
-                                                            <input minlength="9" maxlength="9" id="customNric" placeholder="NRIC" value="S1234567A" style="width: 100%; border: 2px solid #ccc; border-radius: 5px; background: white; color: rgb(42, 45, 51); text-align: left;">
-                                                            <input type="hidden" id="customNricSamlArt" name="SAMLart" />
-                                                            <button autofocus="" type="submit">Login</button>
-                                                            <br>
-                                                            <br>
-                                                        {{/assertEndpoint}}
-                                                        <div class="login__footer">
-                                                            <div class="login-note">
-                                                                 Forgot <a aria-label="Forgot MockPass ID">MockPass ID</a> or <a aria-label="Forgot password">password</a>?
-                                                            </div>
-                                                            <div class="sp-reglink">
-                                                                Don't have an account? <a aria-label="Register now">Register now</a>
-                                                            </div>
-                                                        </div>                                                        
+                                                        <h6>or with your own user</h6>
+
+                                                        <input type="text" name="nric" placeholder="NRIC" value="S1234567A" minlength="9" maxlength="9">
+                                                        {{#showUuid}}<input type="text" name="uuid" placeholder="UUID" value="ef39a074-b64d-4990-a937-6f80772e2bb8" minlength="36" maxlength="36">{{/showUuid}}
+                                                        {{#showUen}}<input type="text" name="uen" placeholder="UEN" value="123456789D" minlength="9" maxlength="10">{{/showUen}}
+
+                                                        {{#assertEndpoint}}<input type="hidden" name="assertEndpoint" value="{{ assertEndpoint }}" />{{/assertEndpoint}}
+                                                        {{#redirectURI}}<input type="hidden" name="redirectURI" value="{{ redirectURI }}" />{{/redirectURI}}
+                                                        {{#relayState}}<input type="hidden" name="relayState" value="{{ relayState }}" />{{/relayState}}
+                                                        {{#state}}<input type="hidden" name="state" value="{{ state }}" />{{/state}}
+                                                        {{#nonce}}<input type="hidden" name="nonce" value="{{ nonce }}" />{{/nonce}}
+
+                                                        <button autofocus="" type="submit">Login</button>
+                                                        <br>
                                                     </form>
+                                                    {{/customProfileConfig}}
+                                                    <br>
+                                                    <div class="login__footer">
+                                                        <div class="login-note">
+                                                            Forgot <a aria-label="Forgot MockPass ID">MockPass ID</a> or <a aria-label="Forgot password">password</a>?
+                                                        </div>
+                                                        <div class="sp-reglink">
+                                                            Don't have an account? <a aria-label="Register now">Register now</a>
+                                                        </div>
+                                                    </div>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </div>

--- a/static/html/login-page.html
+++ b/static/html/login-page.html
@@ -184,10 +184,20 @@
                                                     <form action="{{endpoint}}" class="innate-form" method="get">
                                                         <br>
                                                         <h6>or with your own user</h6>
+                                                        <br>
 
-                                                        <input type="text" name="nric" placeholder="NRIC" value="S1234567A" minlength="9" maxlength="9">
-                                                        {{#showUuid}}<input type="text" name="uuid" placeholder="UUID" value="ef39a074-b64d-4990-a937-6f80772e2bb8" minlength="36" maxlength="36">{{/showUuid}}
-                                                        {{#showUen}}<input type="text" name="uen" placeholder="UEN" value="123456789D" minlength="9" maxlength="10">{{/showUen}}
+                                                        <label for="nric">NRIC</label>
+                                                        <input type="text" name="nric" id="nric" value="S1234567A" minlength="9" maxlength="9">
+
+                                                        {{#showUuid}}
+                                                        <label for="uuid">UUID</label>
+                                                        <input type="text" name="uuid" id="uuid" value="ef39a074-b64d-4990-a937-6f80772e2bb8" minlength="36" maxlength="36">
+                                                        {{/showUuid}}
+
+                                                        {{#showUen}}
+                                                        <label for="uen">UEN</label>
+                                                        <input type="text" name="uen" id="uen" value="123456789D" minlength="9" maxlength="10">
+                                                        {{/showUen}}
 
                                                         {{#assertEndpoint}}<input type="hidden" name="assertEndpoint" value="{{ assertEndpoint }}" />{{/assertEndpoint}}
                                                         {{#redirectURI}}<input type="hidden" name="redirectURI" value="{{ redirectURI }}" />{{/redirectURI}}

--- a/static/myinfo/v3.json
+++ b/static/myinfo/v3.json
@@ -9765,6 +9765,12 @@
           "value": "97399245"
         }
       },
+      "uuid": {
+        "lastupdated": "2020-04-16",
+        "source": "1",
+        "classification": "C",
+        "value": "b6cb9308-733b-42b3-ad38-9b5afc890206"
+      },
       "mailadd": {
         "country": {
           "code": "SG",
@@ -27681,7 +27687,7 @@
         "lastupdated": "2020-04-16",
         "source": "1",
         "classification": "C",
-        "value": ""
+        "value": "632d6cd6-7125-4fcc-b21b-e33aedf05806"
       },
       "mailadd": {
         "country": {


### PR DESCRIPTION
## Problem

- Mockpass offers only limited support for custom identities. Users are mostly locked into a fixed set of identities to choose from. This limits its usefulness as a mock server for writing E2E tests against. Custom NRIC support was added in #142, but this was only for the SAML implementations.
- The OIDC implementations return a single integer (the index) as the user UUID (e.g. `s=S8979373D,u=0` instead of `s=S8979373D,u=a9865837-7bd7-46ac-bef4-42a76a946424` in the `sub` claim). This integer index is not realistic test data as it is not a UUID.

## Solution

**Features**:

- Allow specifying custom NRIC/UUID/UEN via login form or HTTP headers
- Consistent support for both OIDC and SAML

**Improvements**:

- Return realistic UUID in OIDC implementations
- Support OIDC refresh tokens for Corppass

**Bug Fixes**:

- Allow overriding `showLoginPage` to `false` via request header
- Add missing UUIDs for two Myinfo V3 personas

## Before & After Screenshots

**BEFORE**:
![Screenshot 2022-03-11 at 5 45 15 PM](https://user-images.githubusercontent.com/6811428/157844127-eb47046f-0be5-4aef-b6e3-69440649f988.png)

**AFTER**:
![Screenshot 2022-03-14 at 10 59 19 AM](https://user-images.githubusercontent.com/6811428/158097331-d673d417-657f-4b5b-a767-062b651e547b.png)