### PR TITLE
add entityInfo to corppass

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -255,7 +255,7 @@ const oidc = {
       }
     },
     corpPass: async (
-      { nric, uuid, name, isSingPassHolder },
+      { nric, uuid, name, isSingPassHolder, uen },
       iss,
       aud,
       nonce,
@@ -305,6 +305,14 @@ const oidc = {
             CPAccType: 'User',
             CPUID_FullName: name,
             ISSPHOLDER: isSingPassHolder ? 'YES' : 'NO',
+          },
+          entityInfo: {
+            CPEntID: uen,
+            CPEnt_TYPE: 'UEN',
+            CPEnt_Status: 'Registered',
+            CPNonUEN_Country: '',
+            CPNonUEN_RegNo: '',
+            CPNonUEN_Name: '',
           },
         },
       }


### PR DESCRIPTION
## Problem

based on the latest CorpPass spec (v1.3), there is a `EntityInfo` claim in the assertion which contains the UEN. This was missing in mockpass and thus we couldn't handle CorpPass logins properly in development.

**Bug Fixes**:

- add `entityInfo` to CorpPass `idTokenClaims`