### PR TITLE
include request body in params

### DIFF
--- a/lib/crypto/myinfo-signature.js
+++ b/lib/crypto/myinfo-signature.js
@@ -11,13 +11,14 @@ const pki = function pki(authHeader, req, context = {}) {
 
   const url = `${req.protocol}://${req.get('host')}${req.baseUrl}${req.path}`
 
-  const { method: httpMethod, query } = req
+  const { method: httpMethod, query, body } = req
 
   const { signature, app_id, nonce, timestamp } = authHeaderFields
 
   const params = Object.assign(
     {},
     query,
+    body,
     {
       nonce,
       app_id,


### PR DESCRIPTION
## Problem

paiseh, overlooked the request body. `Object.assign` works on nullish values so no need for a guard.

Closes #457 properly this time