### PR TITLE
feat(sgid): add `/.well-known/openid-configuration`

### DIFF
--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -167,6 +167,40 @@ function config(app, { showLoginPage, serviceProvider }) {
     jwk.use = 'sig'
     res.json({ keys: [jwk] })
   })
+
+  app.get('/.well-known/openid-configuration', async (req, res) => {
+    const issuer = `${req.protocol}://${req.get('host')}`
+
+    res.json({
+      issuer,
+      authorization_endpoint: `${issuer}/${PATH_PREFIX}/authorize`,
+      token_endpoint: `${issuer}/${PATH_PREFIX}/token`,
+      userinfo_endpoint: `${issuer}/${PATH_PREFIX}/userinfo`,
+      jwks_uri: `${issuer}/.well-known/jwks.json`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code'],
+      scopes_supported: [
+        'openid',
+        'myinfo.nric_number',
+        'myinfo.name',
+        'myinfo.email',
+        'myinfo.sex',
+        'myinfo.race',
+        'myinfo.mobile_number',
+        'myinfo.registered_address',
+        'myinfo.date_of_birth',
+        'myinfo.passport_number',
+        'myinfo.passport_expiry_date',
+        'myinfo.nationality',
+        'myinfo.residentialstatus',
+        'myinfo.residential',
+        'myinfo.housingtype',
+        'myinfo.hdbtype',
+      ],
+      id_token_signing_alg_values_supported: ['RS256'],
+      subject_types_supported: ['pairwise'],
+    })
+  })
 }
 
 module.exports = config


### PR DESCRIPTION
## Problem and Solution

As sgID and its SDK mature, add `/.well-known/openid-configuration` so that clients (sgID, OpenID and others) can consume it if running on local development machines