### PR TITLE
feat(sgid): Respect OAuth scopes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "plugin:prettier/recommended"
   ],
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "env": {
     "node": true,

--- a/lib/auth-code.js
+++ b/lib/auth-code.js
@@ -4,9 +4,9 @@ const crypto = require('crypto')
 const AUTH_CODE_TIMEOUT = 5 * 60 * 1000
 const profileAndNonceStore = new ExpiryMap(AUTH_CODE_TIMEOUT)
 
-const generateAuthCode = ({ profile, nonce }) => {
+const generateAuthCode = ({ profile, scopes, nonce }) => {
   const authCode = crypto.randomBytes(45).toString('base64')
-  profileAndNonceStore.set(authCode, { profile, nonce })
+  profileAndNonceStore.set(authCode, { profile, scopes, nonce })
   return authCode
 }
 

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -113,7 +113,7 @@ function config(app, { showLoginPage, serviceProvider }) {
     const uuid = (
       req.headers.authorization || req.headers.Authorization
     ).replace('Bearer ', '')
-    console.dir(req.headers)
+    console.warn(JSON.stringify(req.headers))
     const nric = assertions.oidc.singPass.find((p) => p.uuid === uuid).nric
     const persona = assertions.myinfo.v3.personas[nric]
     const name = persona.name.value

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -26,7 +26,7 @@ const idGenerator = {
 const buildAssertURL = (redirectURI, authCode, state) =>
   `${redirectURI}?code=${encodeURIComponent(
     authCode,
-  )}&state=${encodeURIComponent(state)}`
+  )}&state=${encodeURIComponent(state)}}`
 
 function config(app, { showLoginPage, serviceProvider }) {
   const profiles = assertions.oidc.singPass
@@ -35,11 +35,13 @@ function config(app, { showLoginPage, serviceProvider }) {
 
   app.get(`${PATH_PREFIX}/authorize`, (req, res) => {
     const { redirect_uri: redirectURI, state, nonce } = req.query
+    const scopes = req.query.scope ? req.query.scope : 'openid'
+    console.warn(`Requested scope ${scopes}`)
     if (showLoginPage(req)) {
       const values = profiles
         .filter((profile) => assertions.myinfo.v3.personas[profile.nric])
         .map((profile) => {
-          const authCode = generateAuthCode({ profile, nonce })
+          const authCode = generateAuthCode({ profile, scopes, nonce })
           const assertURL = buildAssertURL(redirectURI, authCode, state)
           const id = idGenerator.singPass(profile)
           return { id, assertURL }
@@ -48,7 +50,7 @@ function config(app, { showLoginPage, serviceProvider }) {
       res.send(response)
     } else {
       const profile = defaultProfile
-      const authCode = generateAuthCode({ profile, nonce })
+      const authCode = generateAuthCode({ profile, scopes, nonce })
       const assertURL = buildAssertURL(redirectURI, authCode, state)
       console.warn(
         `Redirecting login from ${req.query.client_id} to ${assertURL}`,
@@ -68,11 +70,13 @@ function config(app, { showLoginPage, serviceProvider }) {
       console.warn(
         `Received auth code ${authCode} from ${aud} and ${req.body.redirect_uri}`,
       )
-      console.warn(`Requested scope ${req.query.scope}`)
-      try {
-        const { profile, nonce } = lookUpByAuthCode(authCode)
 
-        const accessToken = profile.uuid
+      try {
+        const { profile, scopes, nonce } = lookUpByAuthCode(authCode)
+        console.warn(
+          `Profile ${JSON.stringify(profile)} with token scope ${scopes}`,
+        )
+        const accessToken = authCode
         const iss = `${req.protocol}://${req.get('host')}`
 
         const { idTokenClaims, refreshToken } = assertions.oidc.create.singPass(
@@ -98,7 +102,7 @@ function config(app, { showLoginPage, serviceProvider }) {
           access_token: accessToken,
           refresh_token: refreshToken,
           expires_in: 24 * 60 * 60,
-          scope: req.query.scope ? req.query.scope : 'openid',
+          scope: scopes,
           token_type: 'Bearer',
           id_token: idToken,
         })
@@ -110,42 +114,42 @@ function config(app, { showLoginPage, serviceProvider }) {
   )
 
   app.get(`${PATH_PREFIX}/userinfo`, async (req, res) => {
-    const uuid = (
+    const authCode = (
       req.headers.authorization || req.headers.Authorization
     ).replace('Bearer ', '')
-    console.warn(JSON.stringify(req.headers))
+    // eslint-disable-next-line no-unused-vars
+    const { profile, scopes, unused } = lookUpByAuthCode(authCode)
+    const uuid = profile.uuid
     const nric = assertions.oidc.singPass.find((p) => p.uuid === uuid).nric
     const persona = assertions.myinfo.v3.personas[nric]
-    const name = persona.name.value
-    const dateOfBirth = persona.dob.value
 
+    console.warn(`userinfo scopes ${scopes}`)
     const payloadKey = await jose.JWK.createKey('oct', 256, {
       alg: 'A256GCM',
     })
 
-    const encryptedNric = await jose.JWE.createEncrypt(
-      { format: 'compact' },
-      payloadKey,
-    )
-      .update(nric)
-      .final()
-    const encryptedName = await jose.JWE.createEncrypt(
-      { format: 'compact' },
-      payloadKey,
-    )
-      .update(name)
-      .final()
-    const encryptedDateOfBirth = await jose.JWE.createEncrypt(
-      { format: 'compact' },
-      payloadKey,
-    )
-      .update(dateOfBirth)
-      .final()
-    const data = {
-      'myinfo.nric_number': encryptedNric,
-      'myinfo.name': encryptedName,
-      'myinfo.date_of_birth': encryptedDateOfBirth,
+    const encryptPayload = async (field) => {
+      return await jose.JWE.createEncrypt({ format: 'compact' }, payloadKey)
+        .update(field)
+        .final()
     }
+    const encryptedNric = await encryptPayload(nric)
+    const scopesArr = scopes
+      .split(' ')
+      .filter((field) => field !== 'openid' && field !== 'myinfo.nric_number')
+    console.warn(`userinfo scopesArr ${scopesArr}`)
+    const myInfoFields = await Promise.all(
+      scopesArr.map((scope) =>
+        encryptPayload(sgIDScopeToMyInfoField(persona, scope)),
+      ),
+    )
+
+    const data = {}
+    scopesArr.forEach((name, index) => {
+      data[name] = myInfoFields[index]
+    })
+    data['myinfo.nric_number'] = encryptedNric
+    console.warn(`userinfo data: ${data}`)
     const encryptionKey = await jose.JWK.asKey(serviceProvider.pubKey, 'pem')
 
     const plaintextPayloadKey = JSON.stringify(payloadKey.toJSON(true))
@@ -208,42 +212,43 @@ function config(app, { showLoginPage, serviceProvider }) {
   })
 }
 
-// const concatMyInfoRegAddr = (regadd) => {
-//   const line1 = (!!regadd.block.value || !!regadd.street.value)
-//                 ? `${regadd.block.value} ${regadd.street.value}`
-//                 : '';
-//   const line2 = (!!regadd.floor.value || !!regadd.unit.value)
-//                 ? `#${regadd.floor.value} ${regadd.unit.value}`
-//                 : '';
-//   const line3 = (!!regadd.country.desc || !!regadd.postal.value)
-//                 ? `${regadd.country.desc} ${regadd.postal.value}`
-//                 : '';
-//   return `${line1}\n${line2}\n${line3}`
-// }
+const concatMyInfoRegAddr = (regadd) => {
+  const line1 =
+    !!regadd.block.value || !!regadd.street.value
+      ? `${regadd.block.value} ${regadd.street.value}`
+      : ''
+  const line2 =
+    !!regadd.floor.value || !!regadd.unit.value
+      ? `#${regadd.floor.value} ${regadd.unit.value}`
+      : ''
+  const line3 =
+    !!regadd.country.desc || !!regadd.postal.value
+      ? `${regadd.country.desc} ${regadd.postal.value}`
+      : ''
+  return `${line1}\n${line2}\n${line3}`
+}
 
-// // Refer to https://docs.id.gov.sg/data-catalog
-// const SGID_SCOPE_TO_MYINFO_FIELD = (persona, scope) => {
-//   switch(scope) {
-//     // No NRIC as that is always returned by default
-//     case 'myinfo.name':
-//       return persona.name.value
-//     case 'myinfo.email':
-//       return persona.email.value
-//     case 'myinfo.mobile_number':
-//       return persona.mobileno.nbr.value
-//     case 'myinfo.registered_address':
-//       return concatMyInfoRegAddr(persona.regadd)
-//     case 'myinfo.date_of_birth':
-//       return persona.dob.value
-//     case 'myinfo.passport_number':
-//       return persona.passportnumber.value
-//     case 'myinfo.passport_expiry_date':
-//       return persona.passportexpirydate.value
-//     case 'myinfo.email':
-//       return persona.email.value
-//     default:
-//       return ''
-//   }
-// }
+// Refer to https://docs.id.gov.sg/data-catalog
+const sgIDScopeToMyInfoField = (persona, scope) => {
+  switch (scope) {
+    // No NRIC as that is always returned by default
+    case 'myinfo.name':
+      return persona.name.value
+    case 'myinfo.email':
+      return persona.email.value
+    case 'myinfo.mobile_number':
+      return persona.mobileno.nbr.value
+    case 'myinfo.registered_address':
+      return concatMyInfoRegAddr(persona.regadd)
+    case 'myinfo.date_of_birth':
+      return persona.dob.value
+    case 'myinfo.passport_number':
+      return persona.passportnumber.value
+    case 'myinfo.passport_expiry_date':
+      return persona.passportexpirydate.value
+    default:
+      return ''
+  }
+}
 
 module.exports = config

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -217,7 +217,7 @@ const concatMyInfoRegAddr = (regadd) => {
       : ''
   const line2 =
     !!regadd.floor.value || !!regadd.unit.value
-      ? `#${regadd.floor.value} ${regadd.unit.value}`
+      ? `#${regadd.floor.value}-${regadd.unit.value}`
       : ''
   const line3 =
     !!regadd.country.desc || !!regadd.postal.value

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -35,8 +35,8 @@ function config(app, { showLoginPage, serviceProvider }) {
 
   app.get(`${PATH_PREFIX}/authorize`, (req, res) => {
     const { redirect_uri: redirectURI, state, nonce } = req.query
-    const scopes = req.query.scope ? req.query.scope : 'openid'
-    console.warn(`Requested scope ${scopes}`)
+    const scopes = req.query.scope ?? 'openid'
+    console.info(`Requested scope ${scopes}`)
     if (showLoginPage(req)) {
       const values = profiles
         .filter((profile) => assertions.myinfo.v3.personas[profile.nric])
@@ -52,7 +52,7 @@ function config(app, { showLoginPage, serviceProvider }) {
       const profile = defaultProfile
       const authCode = generateAuthCode({ profile, scopes, nonce })
       const assertURL = buildAssertURL(redirectURI, authCode, state)
-      console.warn(
+      console.info(
         `Redirecting login from ${req.query.client_id} to ${assertURL}`,
       )
       res.redirect(assertURL)
@@ -67,13 +67,13 @@ function config(app, { showLoginPage, serviceProvider }) {
       console.log(req.body)
       const { client_id: aud, code: authCode } = req.body
 
-      console.warn(
+      console.info(
         `Received auth code ${authCode} from ${aud} and ${req.body.redirect_uri}`,
       )
 
       try {
         const { profile, scopes, nonce } = lookUpByAuthCode(authCode)
-        console.warn(
+        console.info(
           `Profile ${JSON.stringify(profile)} with token scope ${scopes}`,
         )
         const accessToken = authCode
@@ -123,7 +123,7 @@ function config(app, { showLoginPage, serviceProvider }) {
     const nric = assertions.oidc.singPass.find((p) => p.uuid === uuid).nric
     const persona = assertions.myinfo.v3.personas[nric]
 
-    console.warn(`userinfo scopes ${scopes}`)
+    console.info(`userinfo scopes ${scopes}`)
     const payloadKey = await jose.JWK.createKey('oct', 256, {
       alg: 'A256GCM',
     })
@@ -137,7 +137,7 @@ function config(app, { showLoginPage, serviceProvider }) {
     const scopesArr = scopes
       .split(' ')
       .filter((field) => field !== 'openid' && field !== 'myinfo.nric_number')
-    console.warn(`userinfo scopesArr ${scopesArr}`)
+    console.info(`userinfo scopesArr ${scopesArr}`)
     const myInfoFields = await Promise.all(
       scopesArr.map((scope) =>
         encryptPayload(sgIDScopeToMyInfoField(persona, scope)),
@@ -149,7 +149,6 @@ function config(app, { showLoginPage, serviceProvider }) {
       data[name] = myInfoFields[index]
     })
     data['myinfo.nric_number'] = encryptedNric
-    console.warn(`userinfo data: ${data}`)
     const encryptionKey = await jose.JWK.asKey(serviceProvider.pubKey, 'pem')
 
     const plaintextPayloadKey = JSON.stringify(payloadKey.toJSON(true))

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -152,7 +152,6 @@ function config(app, { showLoginPage, serviceProvider }) {
     const encryptionKey = await jose.JWK.asKey(serviceProvider.pubKey, 'pem')
 
     const plaintextPayloadKey = JSON.stringify(payloadKey.toJSON(true))
-    console.log(plaintextPayloadKey)
     const encryptedPayloadKey = await jose.JWE.createEncrypt(
       { format: 'compact' },
       encryptionKey,

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -113,7 +113,7 @@ function config(app, { showLoginPage, serviceProvider }) {
     const uuid = (
       req.headers.authorization || req.headers.Authorization
     ).replace('Bearer ', '')
-    console.dir(req)
+    console.dir(req.headers)
     const nric = assertions.oidc.singPass.find((p) => p.uuid === uuid).nric
     const persona = assertions.myinfo.v3.personas[nric]
     const name = persona.name.value

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -68,6 +68,7 @@ function config(app, { showLoginPage, serviceProvider }) {
       console.warn(
         `Received auth code ${authCode} from ${aud} and ${req.body.redirect_uri}`,
       )
+      console.warn(`Requested scope ${req.query.scope}`)
       try {
         const { profile, nonce } = lookUpByAuthCode(authCode)
 
@@ -97,7 +98,7 @@ function config(app, { showLoginPage, serviceProvider }) {
           access_token: accessToken,
           refresh_token: refreshToken,
           expires_in: 24 * 60 * 60,
-          scope: 'openid',
+          scope: req.query.scope ? req.query.scope : 'openid',
           token_type: 'Bearer',
           id_token: idToken,
         })
@@ -112,6 +113,7 @@ function config(app, { showLoginPage, serviceProvider }) {
     const uuid = (
       req.headers.authorization || req.headers.Authorization
     ).replace('Bearer ', '')
+    console.dir(req)
     const nric = assertions.oidc.singPass.find((p) => p.uuid === uuid).nric
     const persona = assertions.myinfo.v3.personas[nric]
     const name = persona.name.value
@@ -179,6 +181,9 @@ function config(app, { showLoginPage, serviceProvider }) {
       jwks_uri: `${issuer}/.well-known/jwks.json`,
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code'],
+      // Note: some of these scopes are not yet officially documented
+      // in https://docs.id.gov.sg/data-catalog
+      // So they are not officially supported yet.
       scopes_supported: [
         'openid',
         'myinfo.nric_number',
@@ -202,5 +207,43 @@ function config(app, { showLoginPage, serviceProvider }) {
     })
   })
 }
+
+// const concatMyInfoRegAddr = (regadd) => {
+//   const line1 = (!!regadd.block.value || !!regadd.street.value)
+//                 ? `${regadd.block.value} ${regadd.street.value}`
+//                 : '';
+//   const line2 = (!!regadd.floor.value || !!regadd.unit.value)
+//                 ? `#${regadd.floor.value} ${regadd.unit.value}`
+//                 : '';
+//   const line3 = (!!regadd.country.desc || !!regadd.postal.value)
+//                 ? `${regadd.country.desc} ${regadd.postal.value}`
+//                 : '';
+//   return `${line1}\n${line2}\n${line3}`
+// }
+
+// // Refer to https://docs.id.gov.sg/data-catalog
+// const SGID_SCOPE_TO_MYINFO_FIELD = (persona, scope) => {
+//   switch(scope) {
+//     // No NRIC as that is always returned by default
+//     case 'myinfo.name':
+//       return persona.name.value
+//     case 'myinfo.email':
+//       return persona.email.value
+//     case 'myinfo.mobile_number':
+//       return persona.mobileno.nbr.value
+//     case 'myinfo.registered_address':
+//       return concatMyInfoRegAddr(persona.regadd)
+//     case 'myinfo.date_of_birth':
+//       return persona.dob.value
+//     case 'myinfo.passport_number':
+//       return persona.passportnumber.value
+//     case 'myinfo.passport_expiry_date':
+//       return persona.passportexpirydate.value
+//     case 'myinfo.email':
+//       return persona.email.value
+//     default:
+//       return ''
+//   }
+// }
 
 module.exports = config

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -26,7 +26,7 @@ const idGenerator = {
 const buildAssertURL = (redirectURI, authCode, state) =>
   `${redirectURI}?code=${encodeURIComponent(
     authCode,
-  )}&state=${encodeURIComponent(state)}}`
+  )}&state=${encodeURIComponent(state)}`
 
 function config(app, { showLoginPage, serviceProvider }) {
   const profiles = assertions.oidc.singPass


### PR DESCRIPTION
## Problem

Enables sgID tokens to store information about OAuth scopes, and thus query for them.

Closes #539

## Solution

- Associated the requested scopes with each authcode.
- In `/userinfo` request, use requested scopes to obtain the equivalent MyInfo fields. This is not a 1-1 conversion with MyInfo as not all fields are officially documented yet.

**Features**:

The user can query for more sgID OAuth scopes than previously allowed.

## Tests

Ideally I should write some tests for this. However, I can say I've tested on my local FormSG with sgID integration and this MockPass indeed works.