### PR TITLE
refactor(myinfo): replace node-jose with jose for SSO

### DIFF
--- a/lib/express/myinfo/controllers.js
+++ b/lib/express/myinfo/controllers.js
@@ -5,7 +5,7 @@ const path = require('path')
 const express = require('express')
 const { pick, partition } = require('lodash')
 
-const jose = require('node-jose')
+const jose = require('jose')
 const jwt = require('jsonwebtoken')
 
 const assertions = require('../../assertions')
@@ -31,16 +31,27 @@ module.exports =
     }
 
     const encryptPersona = async (persona) => {
-      const signedPersona = jwt.sign(persona, MOCKPASS_PRIVATE_KEY, {
-        algorithm: 'RS256',
-      })
-      const serviceCertAsKey = await jose.JWK.asKey(serviceProvider.cert, 'pem')
-      const encryptedAndSignedPersona = await jose.JWE.createEncrypt(
-        { format: 'compact' },
-        serviceCertAsKey,
+      /*
+       * We sign and encrypt the persona. It's important to note that although a signature is
+       * usually derived from the payload hash and is thus much smaller than the payload itself,
+       * we're specifically contructeding a JWT, which contains the original payload.
+       *
+       * We then construct a JWE and provide two headers specifying the encryption algorithms used.
+       * You can read about them here: https://www.rfc-editor.org/rfc/inline-errata/rfc7518.html
+       *
+       * These values weren't picked arbitrarily; they were the defaults used by a library we
+       * formerly used: node-jose. We opted to continue using them for backwards compatibility.
+       */
+      const privateKey = await jose.importPKCS8(MOCKPASS_PRIVATE_KEY.toString())
+      const sign = await new jose.SignJWT(persona)
+        .setProtectedHeader({ alg: 'RS256' })
+        .sign(privateKey)
+      const publicKey = await jose.importX509(serviceProvider.cert.toString())
+      const encryptedAndSignedPersona = await new jose.CompactEncrypt(
+        Buffer.from(sign),
       )
-        .update(JSON.stringify(signedPersona))
-        .final()
+        .setProtectedHeader({ alg: 'RSA-OAEP', enc: 'A128CBC-HS256' })
+        .encrypt(publicKey)
       return encryptedAndSignedPersona
     }
 
@@ -142,7 +153,6 @@ module.exports =
               redirect_uri,
             })
           : {}
-
         if (!tokenTemplate) {
           res.status(400).send({
             code: 400,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.0.0",
         "expiry-map": "^2.0.0",
         "express": "^4.16.3",
+        "jose": "^4.14.4",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.11",
         "morgan": "^1.9.1",
@@ -2986,6 +2987,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/jose": {
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7781,6 +7790,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "jose": {
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dotenv": "^16.0.0",
     "expiry-map": "^2.0.0",
     "express": "^4.16.3",
+    "jose": "^4.14.4",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",


### PR DESCRIPTION
## Problem
Replace node-jose package with jose for myInfo SSO.

Addresses part of Issue #328 
Left to resolve use of library in sgID, spcp and v2-ndi files.

## Solution
Replace node-jose with jose library for encryption and signing of data.