### PR TITLE
feat: add more sgid scopes

### DIFF
--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -208,6 +208,13 @@ function config(app, { showLoginPage, serviceProvider }) {
           'myinfo.residential',
           'myinfo.housingtype',
           'myinfo.hdbtype',
+          'myinfo.birth_country',
+          'myinfo.vehicles',
+          'myinfo.name_of_employer',
+          'myinfo.workpass_status',
+          'myinfo.workpass_expiry_date',
+          'myinfo.marital_status',
+          'myinfo.mobile_number_with_prefix',
         ],
         id_token_signing_alg_values_supported: ['RS256'],
         subject_types_supported: ['pairwise'],
@@ -232,28 +239,79 @@ const concatMyInfoRegAddr = (regadd) => {
   return `${line1}\n${line2}\n${line3}`
 }
 
+// Refer to sgid myinfo parser
+const formatMobileNumberWithPrefix = (phone) => {
+  if (!phone || !phone.nbr?.value) {
+    return 'NA'
+  }
+  return phone.prefix?.value && phone.areacode?.value
+    ? `${phone.prefix?.value}${phone.areacode?.value} ${phone.nbr?.value}`
+    : phone.nbr?.value
+}
+
+// Refer to sgid myinfo parser
+const formatVehicles = (vehicles) => {
+  const vehicleObjects =
+    vehicles?.map((vehicle) => ({
+      vehicle_number: vehicle.vehicleno?.value || 'NA',
+    })) || '[]'
+  return vehicleObjects
+}
+
+const defaultUndefinedToNA = (value) => {
+  return value || 'NA'
+}
+
 // Refer to https://docs.id.gov.sg/data-catalog
 const sgIDScopeToMyInfoField = (persona, scope) => {
   switch (scope) {
     // No NRIC as that is always returned by default
     case 'openid':
-      return persona.uuid.value
+      return defaultUndefinedToNA(persona.uuid?.value)
     case 'myinfo.name':
-      return persona.name.value
+      return defaultUndefinedToNA(persona.name?.value)
     case 'myinfo.email':
-      return persona.email.value
+      return defaultUndefinedToNA(persona.email?.value)
+    case 'myinfo.sex':
+      return defaultUndefinedToNA(persona.sex?.desc)
+    case 'myinfo.race':
+      return defaultUndefinedToNA(persona.race?.desc)
     case 'myinfo.mobile_number':
-      return persona.mobileno.nbr.value
+      return defaultUndefinedToNA(persona.mobileno?.nbr?.value)
     case 'myinfo.registered_address':
       return concatMyInfoRegAddr(persona.regadd)
     case 'myinfo.date_of_birth':
-      return persona.dob.value
+      return defaultUndefinedToNA(persona.dob?.value)
     case 'myinfo.passport_number':
-      return persona.passportnumber.value
+      return defaultUndefinedToNA(persona.passportnumber?.value)
     case 'myinfo.passport_expiry_date':
-      return persona.passportexpirydate.value
+      return defaultUndefinedToNA(persona.passportexpirydate?.value)
+    case 'myinfo.nationality':
+      return defaultUndefinedToNA(persona.nationality?.desc)
+    case 'myinfo.residentialstatus':
+      return defaultUndefinedToNA(persona.residentialstatus?.desc)
+    case 'myinfo.residential':
+      return defaultUndefinedToNA(persona.residential?.desc)
+    case 'myinfo.housingtype':
+      return defaultUndefinedToNA(persona.housingtype?.desc)
+    case 'myinfo.hdbtype':
+      return defaultUndefinedToNA(persona.hdbtype?.desc)
+    case 'myinfo.birth_country':
+      return defaultUndefinedToNA(persona.birthcountry?.desc)
+    case 'myinfo.vehicles':
+      return formatVehicles(persona.vehicles)
+    case 'myinfo.name_of_employer':
+      return defaultUndefinedToNA(persona.employment?.value)
+    case 'myinfo.workpass_status':
+      return defaultUndefinedToNA(persona.passstatus?.value)
+    case 'myinfo.workpass_expiry_date':
+      return defaultUndefinedToNA(persona.passexpirydate?.value)
+    case 'myinfo.marital_status':
+      return defaultUndefinedToNA(persona.marital?.desc)
+    case 'myinfo.mobile_number_with_prefix':
+      return formatMobileNumberWithPrefix(persona.mobileno)
     default:
-      return ''
+      return 'NA'
   }
 }
 

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -214,7 +214,7 @@ function config(app, { showLoginPage, serviceProvider }) {
           'myinfo.workpass_status',
           'myinfo.workpass_expiry_date',
           'myinfo.marital_status',
-          'myinfo.mobile_number_with_prefix',
+          'myinfo.mobile_number_with_country_code',
         ],
         id_token_signing_alg_values_supported: ['RS256'],
         subject_types_supported: ['pairwise'],

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -308,7 +308,7 @@ const sgIDScopeToMyInfoField = (persona, scope) => {
       return defaultUndefinedToNA(persona.passexpirydate?.value)
     case 'myinfo.marital_status':
       return defaultUndefinedToNA(persona.marital?.desc)
-    case 'myinfo.mobile_number_with_prefix':
+    case 'myinfo.mobile_number_with_country_code':
       return formatMobileNumberWithPrefix(persona.mobileno)
     default:
       return 'NA'


### PR DESCRIPTION
## Context

sgID is a government identity provider that provides Myinfo data.

## Problem

There are missing some fields that sgID is supporting, hence, RP is not able to test them.

## Solution

Add the following scopes:
```
          'myinfo.birth_country',
          'myinfo.vehicles',
          'myinfo.name_of_employer',
          'myinfo.workpass_status',
          'myinfo.workpass_expiry_date',
          'myinfo.marital_status',
          'myinfo.mobile_number_with_prefix',
```

Default missing fields to `NA` instead of undefined.
