### PR TITLE
fix(ndi): fix missing kid on JWS header

### DIFF
--- a/lib/express/oidc/v2-ndi.js
+++ b/lib/express/oidc/v2-ndi.js
@@ -432,7 +432,7 @@ function config(app, { showLoginPage }) {
         const signedProtectedHeader = {
           alg: 'ES256',
           typ: 'JWT',
-          kid: signingKey.kid,
+          kid: aspSigningKey.kid,
         }
         const signedIdToken = await new jose.CompactSign(
           new TextEncoder().encode(JSON.stringify(idTokenClaims)),


### PR DESCRIPTION
## Problem

After refactor of the NDI implementation to use `jose` library in #595, `kid` is no longer being set on the ID token JWS header. This is breaking verification of the ID token JWS, as RPs need to select the appropriate key from the OP JWKS based on the `kid` value for verification.

Accessing `signingKey.kid` doesn't work as `signingKey` is from `jose.importJWK()`, which is a generic `crypto` library [`KeyObject`](https://nodejs.org/api/crypto.html#class-keyobject) that isn't aware of JWK and so doesn't have the concept of the `kid`. In the [implementation prior to refactor](https://github.com/opengovsg/mockpass/blob/v4.0.8/lib/express/oidc/v2-ndi.js#L291C54-L300) the `signingKey` appears to be some kind of JWK-aware thing so it had the `kid`.

Closes #604 

## Solution

**Bug Fixes**:

- When constructing the ID token JWS, populate the `kid` header value from the original pre-parsing-into-KeyObject JSON object.
