### PR TITLE
refactor: allow export of router

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx commitlint --from origin/master --to HEAD --verbose
+npx commitlint --from origin/main --to HEAD --verbose

--- a/app.js
+++ b/app.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const express = require('express')
+const morgan = require('morgan')
+const path = require('path')
+require('dotenv').config()
+
+const {
+  configOIDC,
+  configOIDCv2,
+  configMyInfo,
+  configSGID,
+} = require('./lib/express')
+
+const serviceProvider = {
+  cert: fs.readFileSync(
+    path.resolve(
+      __dirname,
+      process.env.SERVICE_PROVIDER_CERT_PATH || './static/certs/server.crt',
+    ),
+  ),
+  pubKey: fs.readFileSync(
+    path.resolve(
+      __dirname,
+      process.env.SERVICE_PROVIDER_PUB_KEY || './static/certs/key.pub',
+    ),
+  ),
+}
+
+const cryptoConfig = {
+  signAssertion: process.env.SIGN_ASSERTION !== 'false', // default to true to be backward compatable
+  signResponse: process.env.SIGN_RESPONSE !== 'false',
+  encryptAssertion: process.env.ENCRYPT_ASSERTION !== 'false',
+  resolveArtifactRequestSigned:
+    process.env.RESOLVE_ARTIFACT_REQUEST_SIGNED !== 'false',
+}
+
+const options = {
+  serviceProvider,
+  showLoginPage: (req) =>
+    (req.header('X-Show-Login-Page') || process.env.SHOW_LOGIN_PAGE) === 'true',
+  encryptMyInfo: process.env.ENCRYPT_MYINFO === 'true',
+  cryptoConfig,
+}
+
+const app = express()
+app.use(morgan('combined'))
+
+configOIDC(app, options)
+configOIDCv2(app, options)
+configSGID(app, options)
+
+configMyInfo.consent(app)
+configMyInfo.v3(app, options)
+
+app.enable('trust proxy')
+app.use(express.static(path.join(__dirname, 'public')))
+
+exports.app = app

--- a/index.js
+++ b/index.js
@@ -1,62 +1,7 @@
 #!/usr/bin/env node
-const fs = require('fs')
-const express = require('express')
-const morgan = require('morgan')
-const path = require('path')
-require('dotenv').config()
-
-const {
-  configOIDC,
-  configOIDCv2,
-  configMyInfo,
-  configSGID,
-} = require('./lib/express')
+const { app } = require('./app')
 
 const PORT = process.env.MOCKPASS_PORT || process.env.PORT || 5156
-
-const serviceProvider = {
-  cert: fs.readFileSync(
-    path.resolve(
-      __dirname,
-      process.env.SERVICE_PROVIDER_CERT_PATH || './static/certs/server.crt',
-    ),
-  ),
-  pubKey: fs.readFileSync(
-    path.resolve(
-      __dirname,
-      process.env.SERVICE_PROVIDER_PUB_KEY || './static/certs/key.pub',
-    ),
-  ),
-}
-
-const cryptoConfig = {
-  signAssertion: process.env.SIGN_ASSERTION !== 'false', // default to true to be backward compatable
-  signResponse: process.env.SIGN_RESPONSE !== 'false',
-  encryptAssertion: process.env.ENCRYPT_ASSERTION !== 'false',
-  resolveArtifactRequestSigned:
-    process.env.RESOLVE_ARTIFACT_REQUEST_SIGNED !== 'false',
-}
-
-const options = {
-  serviceProvider,
-  showLoginPage: (req) =>
-    (req.header('X-Show-Login-Page') || process.env.SHOW_LOGIN_PAGE) === 'true',
-  encryptMyInfo: process.env.ENCRYPT_MYINFO === 'true',
-  cryptoConfig,
-}
-
-const app = express()
-app.use(morgan('combined'))
-
-configOIDC(app, options)
-configOIDCv2(app, options)
-configSGID(app, options)
-
-configMyInfo.consent(app)
-configMyInfo.v3(app, options)
-
-app.enable('trust proxy')
-app.use(express.static(path.join(__dirname, 'public')))
 
 app.listen(PORT, (err) =>
   err

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@opengovsg/mockpass",
   "version": "4.0.11",
   "description": "A mock SingPass/CorpPass server for dev purposes",
-  "main": "index.js",
+  "main": "app.js",
   "bin": {
     "mockpass": "index.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon",
+    "start": "nodemon index",
     "cz": "git-cz",
     "lint": "eslint lib",
     "lint-fix": "eslint --fix lib",


### PR DESCRIPTION
Package the express router in MockPass to allow export as npm pkg

- Shard initialisation of express router into `./app`
- Specify package entrypoint as `./app`
  - Change `npm start` to explicitly invoke `nodemon index`