### PR TITLE
fix: wrong desc when residentialstatus is code=C

### DIFF
--- a/static/myinfo/v3.json
+++ b/static/myinfo/v3.json
@@ -1517,7 +1517,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -2415,7 +2415,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -7065,7 +7065,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -8214,7 +8214,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -9302,7 +9302,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -10104,7 +10104,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-02-04",
@@ -12107,7 +12107,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -13817,7 +13817,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "oa": {
@@ -14473,7 +14473,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -15150,7 +15150,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -16153,7 +16153,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -19137,7 +19137,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -24343,7 +24343,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -26126,7 +26126,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "oa": {
@@ -26919,7 +26919,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "lastupdated": "2020-04-16",
@@ -27960,7 +27960,7 @@
         "code": "C",
         "source": "1",
         "classification": "C",
-        "desc": "Citizen"
+        "desc": "CITIZEN"
       },
       "cpfbalances": {
         "oa": {


### PR DESCRIPTION
## Problem

- Mockpass' sgID userinfo endpoint response has residentialstatus as `Citizen`, but production sgID response has `CITIZEN`
- Similarly Myinfo v3 API docs' example has `CITIZEN` in the desc field for this case

(I don't know if the other values like `PR` are correct. Also production sgID returns `NA` for foreigners, and not `ALIEN`, but mockpass doesn't have personas that reflect that right now and I'm not sure how the real Myinfo v3 handles it.)

## Solution

**Bug Fixes**:

- Update myinfo personas file to replace the desc string from `Citizen` to `CITIZEN` where residentialstatus has code `C`.
