### PR TITLE
chore: upgrade husky setup for v9

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,6 @@
+// Skip Husky install in production and CI
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
+  process.exit(0)
+}
+const husky = (await import('husky')).default
+console.log(husky())

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx commitlint --from origin/main --to HEAD --verbose

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@opengovsg/mockpass",
       "version": "4.2.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cz": "git-cz",
     "lint": "eslint lib",
     "lint-fix": "eslint --fix lib",
-    "postinstall": "husky install",
+    "prepare": "node .husky/install.mjs",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },


### PR DESCRIPTION
Remove boilerplate from hook files.

Move husky install from postinstall to prepare, to match current husky init behaviour.

Use husky's [suggested script](https://typicode.github.io/husky/how-to.html) to avoid errors for npm installs without devDependencies.