### PR TITLE
feat: sgID support for pocdex.public_officer_details

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Configure your application (or MockPass) with certificates/keys:
 MockPass accepts any value for `client_id`, `redirect_uri` and `sp_esvcId`.
 The `client_secret` value will be checked if configured, see below.
 
-Only the profiles (NRICs) that have entries in Mockpass' static dataset will
+Only the profiles (NRICs) that have entries in Mockpass' personas dataset will
 succeed, using other NRICs will result in an error. See the list of personas in
 [static/myinfo/v3.json](static/myinfo/v3.json).
 
@@ -119,9 +119,18 @@ Configure your application (or MockPass) with certificates/keys:
 
 MockPass accepts any value for `client_id`, `client_secret` and `redirect_uri`.
 
-Only the profiles (NRICs) that have entries in Mockpass' static dataset will
+Only the profiles (NRICs) that have entries in Mockpass' personas dataset will
 succeed, using other NRICs will result in an error. See the list of personas in 
 [static/myinfo/v3.json](static/myinfo/v3.json).
+
+If the Public Officer Employment Details data item is requested, the 
+`pocdex.public_officer_details` scope data is sourced from the
+`publicofficerdetails` data key (where present) on personas.
+Most personas do not have this data key configured, and will result in a `"NA"`
+response instead of an stringified array. As these personas are not identified
+in the login page dropdown, please check the personas dataset linked above to
+identify them.
+The `pocdex.number_of_employments` scope is not supported.
 
 | Configuration item | Explanation |
 |---|---|

--- a/lib/express/sgid.js
+++ b/lib/express/sgid.js
@@ -268,6 +268,10 @@ const formatVehicles = (vehicles) => {
   return vehicleObjects
 }
 
+const formatJsonStringify = (value) => {
+  return value == undefined ? 'NA' : JSON.stringify(value)
+}
+
 const defaultUndefinedToNA = (value) => {
   return value || 'NA'
 }
@@ -320,6 +324,8 @@ const sgIDScopeToMyInfoField = (persona, scope) => {
       return defaultUndefinedToNA(persona.marital?.desc)
     case 'myinfo.mobile_number_with_country_code':
       return formatMobileNumberWithPrefix(persona.mobileno)
+    case 'pocdex.public_officer_details':
+      return formatJsonStringify(persona.publicofficerdetails)
     default:
       return 'NA'
   }

--- a/static/myinfo/v3.json
+++ b/static/myinfo/v3.json
@@ -1203,7 +1203,16 @@
         "source": "1",
         "classification": "C",
         "desc": ""
-      }
+      },
+      "publicofficerdetails": [
+        {
+          "work_email": "lim_yong_xiang@was.gov.sg",
+          "agency_name": "Work Allocation Singapore",
+          "department_name": "Allocation Central",
+          "employment_type": "Fixed Term",
+          "employment_title": "Senior Software Engineer - LLv1 (Individual Contributor) (WAS)"
+        }
+      ]
     },
     "S9912370B": {
       "edulevel": {


### PR DESCRIPTION
## Problem

Mockpass currently doesn't support sgID clients requesting for the `pocdex.public_officer_details` scope, `"NA"` is always returned.

(It also doesn't support `pocdex.number_of_employments`, but I don't seem to receive that value from sgID, so I don't want to blindly emulate it without knowing what the real values are.)

## Solution

**Features**:

- Supporting adding an `publicofficerdetails` array to personas to serve those details to sgID clients asking for `pocdex.public_officer_details`

## Examples

Example of info to add to persona:

```
"publicofficerdetails": [
  {
    "work_email": "lim_yong_xiang@was.gov.sg",
    "agency_name": "Work Allocation Singapore",
    "department_name": "Allocation Central",
    "employment_type": "Fixed Term",
    "employment_title": "Senior Software Engineer - LLv1 (Individual Contributor) (WAS)"
  }
]
```

Example response from sgid client library's userinfo output, it now returns the string for public officer details with an array, instead of the string `NA`:

```
{
  sub: 'u=952b0342-0649-a6fe-245b-87cfcc3d38da',
  data: {
    'myinfo.name': 'LIM YONG XIANG',
    'pocdex.public_officer_details': '[{"work_email":"lim_yong_xiang@was.gov.sg","agency_name":"Work Allocation Singapore","department_name":"Allocation Central","employment_type":"Fixed Term","employment_title":"Senior Software Engineer - LLv1 (Individual Contributor) (WAS)"}]',
    'myinfo.nric_number': 'S9812379B'
  }
}
```
