### PR TITLE
fix(docker): copy .husky during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/mockpass
 
 COPY package* ./
 
+COPY ./.husky ./.husky
+
 RUN npm ci
 
 COPY . ./


### PR DESCRIPTION
## Problem

FormSG is currently using v4.04 of mockpass however when upgrading mockpass to latest (v4.3.0) there is an error when running docker compose because .husky is not copied so when we run npm ci .husky directory does not exist causing docker build image to fail

## Solution

I copy the .husky directory first to ensure when I run npm ci the prepare script in package.json can run successfully
