### PR TITLE
Update assertions.js to support SFA

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -135,8 +135,12 @@ const oidc = {
       nonce,
       accessToken = crypto.randomBytes(15).toString('hex'),
     ) => {
-      const sub = `s=${nric},u=${uuid}`
-
+      let sub
+      if(nric.startsWith('Y')){
+        sub = `s=${nric},fid='G730Z-H5P96',coi='DE',u=${uuid}`                
+      }else{ 
+        sub = `s=${nric},u=${uuid}`
+      }
       const accessTokenHash = hashToken(accessToken)
 
       const refreshToken = crypto.randomBytes(20).toString('hex')


### PR DESCRIPTION

## Problem
https://stg-id.singpass.gov.sg/docs/authorization/api,  Regular NRIC holders sub claim content include NRIC and UUID (eg. s=S1234567A,u=32af8b7d-ad1d-4c25-8dc7-0a981b533000) 
Singpass Foreign Account holders sub claim content include: Singpass User ID (UID), Foreigner ID (FID), Country-of-Issuance (COI) and UUID (e.g. s=Y7613265T,fid=G730Z-H5P96,coi=DE,u=e2af740e-25b4-4b19-b527-494670952cb0)

Closes [insert issue #]

## Solution

_How did you solve the problem?_
