### PR TITLE
fix: myinfo encryptedAndSignedPersona to use enc A256GCM

### DIFF
--- a/lib/express/myinfo/controllers.js
+++ b/lib/express/myinfo/controllers.js
@@ -50,7 +50,7 @@ module.exports =
       const encryptedAndSignedPersona = await new jose.CompactEncrypt(
         Buffer.from(sign),
       )
-        .setProtectedHeader({ alg: 'RSA-OAEP', enc: 'A128CBC-HS256' })
+        .setProtectedHeader({ alg: 'RSA-OAEP', enc: 'A256GCM' })
         .encrypt(publicKey)
       return encryptedAndSignedPersona
     }


### PR DESCRIPTION
## Problem

1. In myinfo docs (Developers_FAQ.pdf), noted use of A256GCM
<img width="822" alt="image" src="https://github.com/user-attachments/assets/e80dc834-3d19-45b5-8c00-972efc0728cb">

2. Q15 of https://api.singpass.gov.sg/library/myinfo/developers/FAQ

3. current product integration with myinfo test api is also using A256GCM and it is working

## Solution

1. Update A128CBC-HS256 to A256GCM

