### PR TITLE
fix: corppass id token sub

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -186,7 +186,7 @@ const oidc = {
         aud,
       }
 
-      const sub = `s=${nric},u=${uuid},c=SG`
+      const sub = `s=${nric},uuid=${uuid},u=${uen}${nric},c=SG`
 
       const accessTokenClaims = {
         ...baseClaims,


### PR DESCRIPTION
## Problem

In the Corppass v2 ID token, the `sub` claim doesn't have a `uuid` field and the `u` field is the identical when the same UIN logs in with different UENs.

Closes #670 

## Solution

**Bug Fixes**:

- Modify the `sub` claim produced for Corppass to have the persona's uuid in `uuid=` and a simple concatenation of UEN+UIN for `u=`. This is sufficient to ensure that a different `u=` is generated for the case of the same UIN logging in with different UEN.

