### PR TITLE
fix: pin container file to node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:24-slim
 
 WORKDIR /usr/src/mockpass
 


### PR DESCRIPTION
jwt token has a dependency that breaks in node 25
node:slim will always point to the latest node version, which is currently 25
https://github.com/nodejs/node/pull/58211
https://github.com/Azure/azure-sdk-for-js/issues/34243

## Problem

_What problem are you trying to solve? What issue does this close?_

Closes [insert issue #]

## Solution

_How did you solve the problem?_

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Tests

_What tests should be run to confirm functionality?_

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details

