### PR TITLE
fix: update algs to match Corppass

### DIFF
--- a/lib/express/oidc/v2-ndi.js
+++ b/lib/express/oidc/v2-ndi.js
@@ -38,7 +38,12 @@ const singpass_token_endpoint_auth_signing_alg_values_supported = [
   'ES512',
 ]
 
-const corppass_token_endpoint_auth_signing_alg_values_supported = ['ES256']
+const corppass_token_endpoint_auth_signing_alg_values_supported = [
+  'ES256',
+  'ES256K',
+  'ES384',
+  'ES512',
+]
 
 const token_endpoint_auth_signing_alg_values_supported = {
   singPass: singpass_token_endpoint_auth_signing_alg_values_supported,
@@ -52,7 +57,11 @@ const singpass_id_token_encryption_alg_values_supported = [
   'RSA-OAEP-256',
 ]
 
-const corppass_id_token_encryption_alg_values_supported = ['ECDH-ES+A256KW']
+const corppass_id_token_encryption_alg_values_supported = [
+  'ECDH-ES+A256KW',
+  'ECDH-ES+A192KW',
+  'ECDH-ES+A128KW',
+]
 
 const id_token_encryption_alg_values_supported = {
   singPass: singpass_id_token_encryption_alg_values_supported,


### PR DESCRIPTION
## Problem

The algs for Corppass do not match [the real values](https://id.corppass.gov.sg/.well-known/openid-configuration)

Confirmed that it aligns with corppass staging

resolves #665 