### PR TITLE
fix: add `name` to supported scopes (used by Corppass integration)

### DIFF
--- a/lib/express/fapi/utils.js
+++ b/lib/express/fapi/utils.js
@@ -13,6 +13,7 @@ const SupportedScope = {
   OPENID: 'openid',
   UINFIN: 'uinfin',
   USER_IDENTITY: 'user.identity',
+  NAME: 'name',
 }
 const SupportedClaims = {
   NONCE: 'nonce',


### PR DESCRIPTION
## Problem

Federated auth requests from Corppass are rejected by mockpass as the `name` scope is not supported (`Scope name is not supported` error.). This scope is necessary for Corppass to get all info it needs from Singpass in the id token.

## Solution

Add `name` to the supported scopes submitted during PAR.
