### PR TITLE
fix(fapi): updates to FAPI id token, auth ctx msg, dpop handling

### DIFF
--- a/lib/express/fapi/fapi.service.js
+++ b/lib/express/fapi/fapi.service.js
@@ -23,7 +23,12 @@ class FapiService {
       ).pushed_authorization_request_endpoint
     const [, dpopJkt] = await Promise.all([
       verifyClientAssertion(req),
-      verifyDpop(req.headers['dpop'], null, parEndpoint),
+      verifyDpop(
+        req.headers['dpop'],
+        // clients can pass either the DPoP header, or POST body dpop_jkt
+        req.body['dpop_jkt'] ?? null,
+        parEndpoint,
+      ),
     ])
 
     const request_uri = `urn:ietf:params:oauth:request_uri:${crypto
@@ -123,7 +128,11 @@ class FapiService {
     const id_token = {
       sub: profile.uuid,
       sub_attributes: {
+        // coi, type, name are all needed by Corppass
+        account_type: 'standard',
         identity_number: profile.nric,
+        identity_coi: 'SG',
+        name: `USER ${profile.nric}`,
       },
       aud: authRequest.client_id,
       acr: 'urn:singpass:authentication:loa:1', //Mockpass only
@@ -244,6 +253,8 @@ async function verifyDpop(dpop, dpop_jkt, expectedEndpoint) {
       throw new Error('Invalid DPoP jkt')
     return jwkThumbprint
   }
+  // if dpop_jkt was passed in, then we store it for later reference
+  return dpop_jkt
 }
 async function verifyClientAssertion(req) {
   const { client_assertion, client_assertion_type } = req.body
@@ -267,21 +278,40 @@ async function verifyClientAssertion(req) {
 
   const [headerB64] = client_assertion.split('.')
   const header = JSON.parse(Buffer.from(headerB64, 'base64').toString())
-  if (!header.kid) throw new Error('No kid found in client assertion header')
 
-  const keyMap = Object.fromEntries(jwks.keys.map((k) => [k.kid, k]))
-  const keyToTry = await jose.importJWK(keyMap[header.kid], 'ES256')
-  if (!keyToTry) throw new Error('No matching key found for kid')
+  const verifyOpts = {
+    algorithms: ['ES256'],
+    clockTolerance: FapiUtils.dpopConfiguration.DPOP_CLOCK_SKEW,
+    requiredClaims: ['iss', 'sub', 'aud', 'exp', 'iat', 'jti'],
+  }
 
-  const { payload } = await jose
-    .jwtVerify(client_assertion, keyToTry, {
-      algorithms: ['ES256'],
-      clockTolerance: FapiUtils.dpopConfiguration.DPOP_CLOCK_SKEW,
-      requiredClaims: ['iss', 'sub', 'aud', 'exp', 'iat', 'jti'],
-    })
-    .catch(() => {
-      throw new Error('Invalid client assertion signature')
-    })
+  let payload
+  if (header.kid) {
+    // if a kid is provided in the header, we assert a matching jwk
+    const matchingJwk = jwks.keys.find((k) => k.kid === header.kid)
+    if (!matchingJwk) throw new Error('No matching key found for kid')
+    const key = await jose.importJWK(matchingJwk, 'ES256')
+    const result = await jose
+      .jwtVerify(client_assertion, key, verifyOpts)
+      .catch(() => {
+        throw new Error('Invalid client assertion signature')
+      })
+    payload = result.payload
+  } else {
+    // if no kid was provided, then we look for a usable key. this is consistent with
+    // SP auth implementation/behaviour.
+    for (const jwk of jwks.keys) {
+      try {
+        const key = await jose.importJWK(jwk, 'ES256')
+        const result = await jose.jwtVerify(client_assertion, key, verifyOpts)
+        payload = result.payload
+        break
+      } catch {
+        /* empty */
+      }
+    }
+    if (!payload) throw new Error('Invalid client assertion signature')
+  }
 
   if (payload.aud !== FapiUtils.getFapiOpenIdConfiguration(req).issuer)
     throw new Error('Invalid client assertion aud')
@@ -400,7 +430,8 @@ function verifyAuthenticationContext(
   authenticationContextType,
   authenticationContextMessage,
 ) {
-  //Not enforced if not provided. This parameter seems to fail when provided for some login apps
+  // for non-login apps, this is rejected if present, and since mockpass
+  // won't have context of the app type, we just make it optional
   if (!authenticationContextType) return
   if (
     !FapiUtils.AllowedAuthenticationContextTypes.includes(
@@ -408,11 +439,9 @@ function verifyAuthenticationContext(
     )
   )
     throw new Error('Invalid authentication context type')
-  assert(
-    authenticationContextMessage,
-    'Authentication context message is required',
-  )
-  if (authenticationContextMessage.length > 100)
+
+  // this is optional by SP FAPI spec, and should only be validated when provided.
+  if (authenticationContextMessage && authenticationContextMessage.length > 100)
     throw new Error(
       'Authentication context message must be less than 100 characters',
     )


### PR DESCRIPTION
## Problem

Some inconsistencies in the FAPI endpoints responses:
- id token `sub_attributes` is missing some claims needed by CP
- `authentcation_context_message` is required, instead of optional
- request body `dpop_jkt` is not supported for PAR
- `kid` matching for CA validation is required, while SP supports key lookup by verification

## Solution

This adds the following changes:
- identity_coi, account_type, name to id_token.sub_attributes
- make authentication_context_message optional (by spec)
- support request body dpop_jkt during PAR (by spec)
- do jwk lookup during CA validation if no kid (same as SP auth)
