### PR TITLE
fix: remove exp from required DPoP claims

### DIFF
--- a/lib/express/fapi/fapi.service.js
+++ b/lib/express/fapi/fapi.service.js
@@ -220,7 +220,7 @@ async function verifyDpop(dpop, dpop_jkt, expectedEndpoint) {
       const key = await jose.importJWK(jwk, 'ES256')
       await jose.jwtVerify(dpopToken, key, {
         clockTolerance: FapiUtils.dpopConfiguration.DPOP_CLOCK_SKEW,
-        requiredClaims: ['jti', 'iat', 'exp', 'htu', 'htm'],
+        requiredClaims: ['jti', 'iat', 'htu', 'htm'],
       })
     } catch (error) {
       throw new Error(`Invalid DPoP token signature, ${error.message}`)


### PR DESCRIPTION
## Problem

DPoP verification in `verifyDpop` required an `exp` claim on the DPoP proof JWT.
Per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449), a DPoP proof JWT is
**not** required to carry an `exp` claim

 GovTechSG's [singpass-myinfo-oidc-helper](https://github.com/GovTechSG/singpass-myinfo-oidc-helper) generates DPoP proofs without an `exp` claim. Because mockpass required exp, DPoP proofs from that client were rejected, so integrations using the sdk couldn't authenticate against mockpass.

Closes #813 

## Solution

**Bug Fixes**:

- Remove `exp` from `requiredClaims` in `verifyDpop`. Required claims are now
`jti`, `iat`, `htu`, and `htm`.

## Before & After Screenshots

**BEFORE**:
N/A

**AFTER**:
N/A

## Tests

- [ ] Verified valid DPoP proof without `exp` is accepted
- [ ] Verified `jti` / `iat` / `htu` / `htm` are still required

## Deploy Notes

