### PR TITLE
feat(par): add x-auth-session-id to response header

### DIFF
--- a/lib/express/fapi/fapi.controller.js
+++ b/lib/express/fapi/fapi.controller.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto')
 const FapiService = require('./fapi.service.js')
 const FapiUtils = require('./utils.js')
 const express = require('express')
@@ -33,6 +34,7 @@ function config(app) {
   app.post(`${fapiRoutesBasePath}/par`, async (req, res) => {
     try {
       const request_uri = await service.handleParRequest(req)
+      res.set('x-auth-session-id', crypto.randomUUID())
       return res.status(201).send({ request_uri, expires_in: 60 })
     } catch (e) {
       return res.status(400).send({ error: e.message })


### PR DESCRIPTION
**Features**:

- Added `x-auth-session-id` in par response headers that can be utlized for correlation.
Note: The PAR spec (RFC 9126) defines the response body requirements - request_uri and expires_in in the JSON body. The spec doesn't restrict additional response headers. Adding custom headers like `x-auth-session-id` is a transport-level concern outside the scope of OIDC. 

## Tests

Verified with local app

